### PR TITLE
Changing the default user profile name to lowercase 

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
@@ -26,7 +26,7 @@ public class X509CertificateConstants {
     public static final String AUTHENTICATOR_NAME = "x509CertificateAuthenticator";
     public static final String AUTHENTICATOR_FRIENDLY_NAME = "X509Certificate";
     public static final String USER_CERTIFICATE = "http://wso2.org/claims/userCertificate";
-    public static final String DEFAULT = "Default";
+    public static final String DEFAULT = "default";
     public static final String X_509_CERTIFICATE = "javax.servlet.request.X509Certificate";
     public static final String SESSION_DATA_KEY = "sessionDataKey";
     public static final String COMMON_AUTH = "commonauth";


### PR DESCRIPTION
This is to prevent the authenticator from creating a new user profile for JDBC user stores to add the certificate.
