### PR TITLE
X509 Certificate Validation with CRL and OCSP

### DIFF
--- a/component/authentication-endpoint/pom.xml
+++ b/component/authentication-endpoint/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.endpoint</artifactId>

--- a/component/authentication-endpoint/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/component/authentication-endpoint/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -14,6 +14,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-unknown.error.code=500
+certificateNotFound.error.message=Could not find X509 certificate in browser!
+userNotFound.error.message=Couldn't find the username for configured X509Certificate's attribute!
+userNamesConflict.error.message=Couldn't find any certificate belongs to this user!
+userNotFoundInUserStore.error.message=Couldn't find X509 certificate's user in user store!
+unknown.error.code=51007
 certificate.not.found=X509 Certificate not found
-unknown.error.message=Some thing went wrong, please retry!
+unknown.error.message=Something went wrong, please retry!
+not.valid.certificate=Provided Client X509 Certificate is not valid!
+fail.validation.certificate=Could not validate the provided client certificate!
+    }

--- a/component/authentication-endpoint/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/component/authentication-endpoint/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -14,7 +14,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-certificateNotFound.error.message=Could not find X509 certificate in browser!
 unknown.error.code=500
 certificate.not.found=X509 Certificate not found
 unknown.error.message=Some thing went wrong, please retry!

--- a/component/authentication-endpoint/src/main/webapp/x509CertificateError.jsp
+++ b/component/authentication-endpoint/src/main/webapp/x509CertificateError.jsp
@@ -42,12 +42,8 @@
         if (Boolean.parseBoolean(request.getParameter("authFailure"))) {
             authenticationFailed = "true";
 
-            if (request.getParameter("errorCode") != null) {
-                errorCode = request.getParameter("errorCode");
-
-                if (errorCode.equalsIgnoreCase("404")) {
-                    errorMessage = resourceBundle.getString("certificateNotFound.error.message");
-                }
+            if (request.getParameter("errorMsg") != null) {
+                errorMessage = request.getParameter("errorMsg");
             }
         }
     %>

--- a/component/authentication-endpoint/src/main/webapp/x509CertificateError.jsp
+++ b/component/authentication-endpoint/src/main/webapp/x509CertificateError.jsp
@@ -42,8 +42,22 @@
         if (Boolean.parseBoolean(request.getParameter("authFailure"))) {
             authenticationFailed = "true";
 
-            if (request.getParameter("errorMsg") != null) {
-                errorMessage = request.getParameter("errorMsg");
+            if (request.getParameter("errorCode") != null) {
+                errorCode = request.getParameter("errorCode");
+
+                if (errorCode.equalsIgnoreCase("18013")) {
+                    errorMessage = resourceBundle.getString("certificateNotFound.error.message");
+                } else if (errorCode.equalsIgnoreCase("18003")) {
+                    errorMessage = resourceBundle.getString("userNotFound.error.message");
+                } else if (errorCode.equalsIgnoreCase("20015")) {
+                    errorMessage = resourceBundle.getString("userNamesConflict.error.message");
+                } else if (errorCode.equalsIgnoreCase("17001")) {
+                    errorMessage = resourceBundle.getString("userNotFoundInUserStore.error.message");
+                } else if (errorCode.equalsIgnoreCase("18015")) {
+                    errorMessage = resourceBundle.getString("not.valid.certificate");
+                } else if (errorCode.equalsIgnoreCase("17003")) {
+                    errorMessage = resourceBundle.getString("fail.validation.certificate");
+                }
             }
         }
     %>

--- a/component/authentication-endpoint/src/main/webapp/x509CertificateError.jsp
+++ b/component/authentication-endpoint/src/main/webapp/x509CertificateError.jsp
@@ -53,6 +53,12 @@
                     errorMessage = resourceBundle.getString("userNamesConflict.error.message");
                 } else if (errorCode.equalsIgnoreCase("17001")) {
                     errorMessage = resourceBundle.getString("userNotFoundInUserStore.error.message");
+                } else if (errorCode.equalsIgnoreCase("18003")) {
+                    errorMessage = resourceBundle.getString("userNotFound.error.message");
+                } else if (errorCode.equalsIgnoreCase("20015")) {
+                    errorMessage = resourceBundle.getString("userNamesConflict.error.message");
+                } else if (errorCode.equalsIgnoreCase("17001")) {
+                    errorMessage = resourceBundle.getString("userNotFoundInUserStore.error.message");
                 } else if (errorCode.equalsIgnoreCase("18015")) {
                     errorMessage = resourceBundle.getString("not.valid.certificate");
                 } else if (errorCode.equalsIgnoreCase("17003")) {

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector</artifactId>

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+            <artifactId>org.wso2.carbon.extension.identity.x509Certificate.validation</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -70,8 +70,8 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                 String redirectUrl = errorPageUrl + ("?" + FrameworkConstants.SESSION_DATA_KEY + "="
                         + authenticationContext.getContextIdentifier()) + "&" + X509CertificateConstants.AUTHENTICATORS
                         + "=" + getName() + X509CertificateConstants.RETRY_PARAM_FOR_CHECKING_CERTIFICATE
-                        + authenticationContext.getProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE);
-                authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE, "");
+                        + authenticationContext.getProperty(X509CertificateConstants.ErrorMessage.X509_CERTIFICATE_ERROR_MESSAGE);
+                authenticationContext.setProperty(X509CertificateConstants.ErrorMessage.X509_CERTIFICATE_ERROR_MESSAGE, "");
 
                 if (log.isDebugEnabled()) {
                     log.debug("Redirect to error page: " + redirectUrl);
@@ -155,14 +155,16 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                         log.debug("X509Certificate is allowed to user: " + userName);
                     }
                 } else {
+                    authenticationContext.setProperty(X509CertificateConstants.ErrorMessage.X509_CERTIFICATE_ERROR_MESSAGE,
+                            X509CertificateConstants.ErrorMessage.X509_CERTIFICATE_NOT_VALID_ERROR_CODE);
                     throw new AuthenticationFailedException("X509Certificate is not valid");
                 }
             } else {
                 throw new AuthenticationFailedException("X509Certificate object is null");
             }
         } else {
-            authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,
-                    X509CertificateConstants.X509_CERTIFICATE_NOT_FOUND_ERROR_CODE);
+            authenticationContext.setProperty(X509CertificateConstants.ErrorMessage.X509_CERTIFICATE_ERROR_MESSAGE,
+                    X509CertificateConstants.ErrorMessage.X509_CERTIFICATE_NOT_FOUND_ERROR_CODE);
             throw new AuthenticationFailedException("Unable to find X509 Certificate in browser");
         }
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -148,20 +148,12 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                 if (StringUtils.isEmpty(userName)) {
                     throw new AuthenticationFailedException("username can't be empty");
                 }
-                if (!X509CertificateUtil.isCertificateExist(userName)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("X509Certificate does not exit for user: " + userName);
-                    }
-                    X509CertificateUtil.addCertificate(userName, data);
+
+                if (X509CertificateUtil.validateCerts(userName, data)) {
                     allowUser(userName, claims, cert, authenticationContext);
                     if (log.isDebugEnabled()) {
-                        log.debug("X509Certificate added and allowed to user: " + userName);
+                        log.debug("X509Certificate is allowed to user: " + userName);
                     }
-                } else if (X509CertificateUtil.validateCerts(userName, data)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("X509Certificate exits and getting validated");
-                    }
-                    allowUser(userName, claims, cert, authenticationContext);
                 } else {
                     throw new AuthenticationFailedException("X509Certificate is not valid");
                 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
@@ -41,17 +41,26 @@ public class X509CertificateConstants {
     public static final String AUTHENTICATION_ENDPOINT = "https://localhost:8443/x509-certificate-servlet";
     public static final String AUTHENTICATION_ENDPOINT_PARAMETER = "AuthenticationEndpoint";
     public static final String USERNAME = "username";
+    public static final String ENFORCE_SELF_REGISTRATION = "EnforceSelfRegistration";
     public static final String SUCCESS = "success";
     public static final String RETRY_PARAM_FOR_CHECKING_CERTIFICATE =
-            "&authFailure=true&errorMsg=";
+            "&authFailure=true&errorCode=";
     public static final String ERROR_PAGE = "x509certificateauthenticationendpoint/x509CertificateError.jsp";
     public static final String CLAIM_URI = "setClaimURI";
     public static final String AUTHENTICATORS = "authenticators";
+    public static final String X509_CERTIFICATE_ERROR_CODE = "X509CertificateErrorCode";
+    public static final String X509_CERTIFICATE_NOT_FOUND_ERROR_CODE = "18013";
+    public static final String USERNAME_CONFLICT = "20015";
+    public static final String USERNAME_NOT_FOUND_FOR_X509_CERTIFICATE_ATTRIBUTE = "18003";
     public static final String X509_CERTIFICATE_USERNAME = "X509CertificateUsername";
+    public static final String USER_NOT_FOUND = "17001";
+    public static final String X509_CERTIFICATE_NOT_VALID_ERROR_CODE = "18015";
+    public static final String X509_CERTIFICATE_NOT_VALIDATED_ERROR_CODE = "17003";
 
     public class ErrorMessage {
         public static final String X509_CERTIFICATE_ERROR_MESSAGE = "X509CertificateErrorMessage";
         public static final String X509_CERTIFICATE_NOT_FOUND_ERROR_CODE = "Could not find X509 Certificate in browser!";
         public static final String X509_CERTIFICATE_NOT_VALID_ERROR_CODE = "Provided Client X509 Certificate is not valid!";
+        public static final String X509_CERTIFICATE_NOT_VALIDATED_ERROR_CODE = "Could not validate the provided client certificate!";
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
@@ -43,11 +43,15 @@ public class X509CertificateConstants {
     public static final String USERNAME = "username";
     public static final String SUCCESS = "success";
     public static final String RETRY_PARAM_FOR_CHECKING_CERTIFICATE =
-            "&authFailure=true&errorCode=";
+            "&authFailure=true&errorMsg=";
     public static final String ERROR_PAGE = "x509certificateauthenticationendpoint/x509CertificateError.jsp";
     public static final String CLAIM_URI = "setClaimURI";
     public static final String AUTHENTICATORS = "authenticators";
-    public static final String X509_CERTIFICATE_ERROR_CODE = "X509CertificateErrorCode";
-    public static final String X509_CERTIFICATE_NOT_FOUND_ERROR_CODE = "404";
     public static final String X509_CERTIFICATE_USERNAME = "X509CertificateUsername";
+
+    public class ErrorMessage {
+        public static final String X509_CERTIFICATE_ERROR_MESSAGE = "X509CertificateErrorMessage";
+        public static final String X509_CERTIFICATE_NOT_FOUND_ERROR_CODE = "Could not find X509 Certificate in browser!";
+        public static final String X509_CERTIFICATE_NOT_VALID_ERROR_CODE = "Provided Client X509 Certificate is not valid!";
+    }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -27,14 +27,19 @@ import org.wso2.carbon.identity.application.authentication.framework.config.buil
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
+import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManager;
+import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManagerImpl;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import org.apache.commons.lang.StringUtils;
 
-import javax.security.cert.CertificateException;
-import javax.security.cert.X509Certificate;
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +71,9 @@ public class X509CertificateUtil {
                     log.debug("The user certificate is " + userCertificate);
                 }
                 if (StringUtils.isNotEmpty(userCertificate)) {
-                    x509Certificate = X509Certificate.getInstance(Base64.decode(userCertificate));
+                    CertificateFactory cf = CertificateFactory.getInstance("X509");
+                    x509Certificate = (X509Certificate) cf.generateCertificate
+                            (new ByteArrayInputStream(Base64.decode(userCertificate)));
                 } else {
                     return null;
                 }
@@ -77,7 +84,7 @@ public class X509CertificateUtil {
                 throw new AuthenticationFailedException("Cannot find the user realm for the given tenant domain : " +
                         CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
             }
-        } catch (javax.security.cert.CertificateException e) {
+        } catch (CertificateException e) {
             throw new AuthenticationFailedException("Error while decoding the certificate ", e);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new AuthenticationFailedException("Error while user manager for tenant id ", e);
@@ -99,7 +106,9 @@ public class X509CertificateUtil {
         UserRealm userRealm = getUserRealm(username);
         try {
             if (userRealm != null) {
-                X509Certificate x509Certificate = X509Certificate.getInstance(certificateBytes);
+                CertificateFactory cf = CertificateFactory.getInstance("X509");
+                X509Certificate x509Certificate = (X509Certificate) cf.generateCertificate
+                        (new ByteArrayInputStream(certificateBytes));
                 claims.put(getClaimUri(), Base64.encode(x509Certificate.getEncoded()));
                 String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
                 userRealm.getUserStoreManager().setUserClaimValues(tenantAwareUsername, claims,
@@ -124,6 +133,33 @@ public class X509CertificateUtil {
         return true;
     }
 
+    public static void deleteCertificate(String username)
+            throws AuthenticationFailedException {
+        String[] claims = new String[1];
+        UserRealm userRealm = getUserRealm(username);
+        try {
+            if (userRealm != null) {
+                claims[0] = getClaimUri();
+                String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+                userRealm.getUserStoreManager().deleteUserClaimValues(tenantAwareUsername, claims,
+                        X509CertificateConstants.DEFAULT);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("UserRealm is null for username: " + username);
+                }
+                throw new AuthenticationFailedException("Cannot find the user realm for the given tenant domain : " +
+                        CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+            }
+        } catch (UserStoreException e) {
+            throw new AuthenticationFailedException("Error while deleting certificate of user: " + username, e);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new AuthenticationFailedException("Error while user manager for tenant id", e);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("X509 certificate is deleted for user: " + username);
+        }
+    }
+
     /**
      * Validate the certificate against with given certificate.
      *
@@ -135,18 +171,45 @@ public class X509CertificateUtil {
     public static boolean validateCerts(String userName, byte[] certificateBytes)
             throws AuthenticationFailedException {
         X509Certificate x509Certificate;
-        boolean validateResult;
         try {
-            x509Certificate = X509Certificate.getInstance(certificateBytes);
-            validateResult = x509Certificate.equals(getCertificate(userName));
-        } catch (javax.security.cert.CertificateException e) {
+            CertificateFactory cf = CertificateFactory.getInstance("X509");
+            x509Certificate = (X509Certificate) cf.generateCertificate
+                    (new ByteArrayInputStream(certificateBytes));
+            RevocationValidationManager revocationValidationManager = new RevocationValidationManagerImpl();
+            boolean isRevoked = revocationValidationManager.verifyRevocationStatus(x509Certificate);
+
+            if (isRevoked) {
+                if (X509CertificateUtil.isCertificateExist(userName) &&
+                        x509Certificate.equals(getCertificate(userName))) {
+                    X509CertificateUtil.deleteCertificate(userName);
+                }
+                return false;
+            } else {
+                if (!X509CertificateUtil.isCertificateExist(userName)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("X509Certificate does not exit for user: " + userName);
+                    }
+                    X509CertificateUtil.addCertificate(userName, certificateBytes);
+                    if (log.isDebugEnabled()) {
+                        log.debug("X509Certificate is added to user: " + userName);
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("X509Certificate exits and getting validated");
+                    }
+                    if (!x509Certificate.equals(getCertificate(userName))) {
+                        return false;
+                    }
+                }
+            }
+        } catch (CertificateException e) {
             throw new AuthenticationFailedException("Error while retrieving certificate ", e);
+        } catch (CertificateValidationException e) {
+            throw new AuthenticationFailedException("Error while validating certificate ", e);
         }
-        if (log.isDebugEnabled()) {
-            log.debug("X509 certificate validation is completed and the result is " + validateResult);
-        }
-        return validateResult;
+        return true;
     }
+
 
     /**
      * Check availability of certificate.

--- a/component/validation/pom.xml
+++ b/component/validation/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+        <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
+        <version>2.0.4-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>org.wso2.carbon.extension.identity.x509Certificate.validation</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - X509Certificate Validation</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.registry.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>1.4.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.identity.x509Certificate.validation.internal
+                        </Private-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.x509Certificate.validation.internal,
+                            org.wso2.carbon.identity.x509Certificate.validation.*,
+                        </Export-Package>
+                        <Import-Package>
+                            !javax.xml.namespace,
+                            javax.xml.namespace; version=0.0.0,
+                            javax.servlet; version=2.4.0,
+                            javax.servlet.http; version=2.4.0,
+                            org.wso2.carbon.identity.application.common.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationException.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation;
+
+public class CertificateValidationException extends Exception {
+
+    public CertificateValidationException(String message) {
+        super(message);
+    }
+
+    public CertificateValidationException(Throwable throwable) {
+        super(throwable);
+    }
+
+    public CertificateValidationException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.x509Certificate.validation.internal.CertValidationDataHolder;
+import org.wso2.carbon.identity.x509Certificate.validation.model.Validator;
+import org.wso2.carbon.identity.x509Certificate.validation.validator.RevocationValidator;
+import org.wso2.carbon.registry.core.Collection;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
+
+public class CertificateValidationUtil {
+
+    private static Log log = LogFactory.getLog(CertificateValidationUtil.class);
+
+    public static List<RevocationValidator> loadValidatorConfig() throws CertificateValidationException {
+        String validatorConfRegPath = X509CertificateValidationConstants.VALIDATOR_CONF_REG_PATH;
+        List<RevocationValidator> validators = new ArrayList<>();
+
+        try {
+            //get tenant registry for loading validator configurations
+            Registry registry = getGovernanceRegistry(
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+            if (registry.resourceExists(validatorConfRegPath)) {
+                Collection collection = (Collection) registry.get(validatorConfRegPath);
+                if (collection != null) {
+                    String[] children = collection.getChildren();
+                    for (String child : children) {
+                        Resource resource = registry.get(child);
+                        Validator validator = resourceToValidatorObject(resource);
+                        RevocationValidator revocationValidator;
+                        try {
+                            Class<?> clazz = Class.forName(validator.getName());
+                            Constructor<?> constructor = clazz.getConstructor();
+                            revocationValidator = (RevocationValidator) constructor.newInstance();
+                        } catch (ClassNotFoundException | InvocationTargetException | NoSuchMethodException |
+                                InstantiationException | IllegalAccessException e) {
+                            continue;
+                        }
+                        revocationValidator.setEnable(validator.getEnabled());
+                        revocationValidator.setPriority(validator.getPriority());
+                        validators.add(revocationValidator);
+                    }
+                }
+            }
+        } catch (RegistryException e) {
+            throw new CertificateValidationException("Error while loading validator configurations from registry.", e);
+        }
+        return validators;
+    }
+
+    public static void addDefaultValidatorConfig(String tenantDomain) {
+        if(tenantDomain == null) {
+            tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        }
+        List<Validator> defaultValidatorConfig = getDefaultValidatorConfig();
+
+        // iterate through the validator config list and write to the the registry
+        for (Validator validator : defaultValidatorConfig) {
+            String validatorConfRegPath = X509CertificateValidationConstants.VALIDATOR_CONF_REG_PATH +
+                    PATH_SEPARATOR + getNormalizedName(validator.getDisplayName());
+            try {
+                Registry registry = getGovernanceRegistry(tenantDomain);
+                if (!registry.resourceExists(validatorConfRegPath)) {
+                    addValidatorConfigInRegistry(registry, validatorConfRegPath, validator);
+                    if (log.isDebugEnabled()) {
+                        String msg = "Validator configuration for %s is added to %s tenant registry.";
+                        log.debug(String.format(msg, validator.getDisplayName(), tenantDomain));
+                    }
+                }
+            } catch (RegistryException | CertificateValidationException e) {
+                log.error("Error while adding validator configurations in registry.", e);
+            }
+        }
+    }
+
+    public static List<Validator> getDefaultValidatorConfig() {
+        String configFilePath = CarbonUtils.getCarbonConfigDirPath() + File.separator +
+                X509CertificateValidationConstants.VALIDATOR_CONF_DIRECTORY + File.separator +
+                X509CertificateValidationConstants.VALIDATOR_CONF_FILE;
+
+        List<Validator> defaultValidatorConfig = new ArrayList<>();
+        File configFile = new File(configFilePath);
+        if (!configFile.exists()) {
+            log.error("Certification validator Configuration File is not present at: " + configFilePath);
+        }
+
+        XMLStreamReader xmlStreamReader = null;
+        InputStream inputStream = null;
+        try {
+            inputStream = new FileInputStream(configFile);
+            StAXOMBuilder builder = new StAXOMBuilder(inputStream);
+
+            OMElement documentElement = builder.getDocumentElement();
+            Iterator iterator = documentElement.getChildElements();
+            while (iterator.hasNext()) {
+                OMElement omElement = (OMElement) iterator.next();
+                String name = omElement.getAttributeValue(
+                        new QName(X509CertificateValidationConstants.VALIDATOR_CONF_NAME));
+                String displayName = omElement.getAttributeValue(
+                        new QName(X509CertificateValidationConstants.VALIDATOR_CONF_DISPLAY_NAME));
+                String enable = omElement.getAttributeValue(
+                        new QName(X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE));
+
+                Map<String, String> validatorProperties = getValidatorProperties(omElement);
+                String priority = validatorProperties.get(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY);
+
+                Validator validator = new Validator();
+                validator.setName(name);
+                validator.setDisplayName(displayName);
+                validator.setEnabled(Boolean.parseBoolean(enable));
+                validator.setPriority(Integer.parseInt(priority));
+
+                defaultValidatorConfig.add(validator);
+            }
+        } catch (XMLStreamException | FileNotFoundException e) {
+            log.warn("Error while loading default validator configurations to the registry.", e);
+        } finally {
+            try {
+                if (xmlStreamReader != null) {
+                    xmlStreamReader.close();
+                }
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (XMLStreamException e) {
+                log.error("Error while closing XML stream", e);
+            } catch (IOException e) {
+                log.error("Error while closing input stream", e);
+            }
+        }
+
+        return defaultValidatorConfig;
+    }
+
+    private static void addValidatorConfigInRegistry(Registry registry, String validatorConfRegPath, Validator validator)
+            throws RegistryException {
+        Resource resource = registry.newResource();
+        resource.addProperty(X509CertificateValidationConstants.VALIDATOR_CONF_NAME, validator.getName());
+        resource.addProperty(X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE,
+                Boolean.toString(validator.getEnabled()));
+        resource.addProperty(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY,
+                Integer.toString(validator.getPriority()));
+        registry.put(validatorConfRegPath, resource);
+    }
+
+    private static Map<String, String> getValidatorProperties(OMElement validatorElement) {
+        Map<String, String> validatorProperties = new HashMap<>();
+        Iterator it = validatorElement.getChildElements();
+        while (it.hasNext()) {
+            OMElement element = (OMElement) it.next();
+            String elementName = element.getLocalName();
+            String elementText = element.getText();
+            if (StringUtils.equalsIgnoreCase(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY, elementName)) {
+                validatorProperties.put(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY, elementText);
+            }
+        }
+        return validatorProperties;
+    }
+
+    private static String getNormalizedName(String name) {
+        if (StringUtils.isNotBlank(name)) {
+            return name.replaceAll("\\s+", "").toLowerCase();
+        }
+        throw new IllegalArgumentException("Invalid validator name provided : " + name);
+    }
+
+
+    private static Registry getGovernanceRegistry(String tenantDomain) throws CertificateValidationException {
+        Registry registry = null;
+        try {
+            registry = CertValidationDataHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(
+                    CertValidationDataHolder.getInstance().getRealmService().getTenantManager().getTenantId(tenantDomain));
+        } catch (UserStoreException | RegistryException e) {
+            throw new CertificateValidationException("Error while get tenant registry." , e);
+        }
+        return registry;
+    }
+
+    private static Validator resourceToValidatorObject(Resource resource) {
+        Validator validator = new Validator();
+        validator.setName(resource.getProperty(X509CertificateValidationConstants.VALIDATOR_CONF_NAME));
+        validator.setEnabled(Boolean.parseBoolean(resource.getProperty(
+                X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE)));
+        validator.setPriority(Integer.parseInt(resource.getProperty(
+                X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY)));
+        return validator;
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -20,11 +20,22 @@ package org.wso2.carbon.identity.x509Certificate.validation;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.axiom.om.util.*;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.DERIA5String;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMWriter;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.x509Certificate.validation.internal.CertValidationDataHolder;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificate;
 import org.wso2.carbon.identity.x509Certificate.validation.model.Validator;
 import org.wso2.carbon.identity.x509Certificate.validation.validator.RevocationValidator;
 import org.wso2.carbon.registry.core.Collection;
@@ -34,29 +45,85 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.CarbonUtils;
 
+import javax.xml.bind.DatatypeConverter;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import java.io.IOException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
+import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.net.URLEncoder;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.*;
+import java.util.*;
+import org.apache.axiom.om.util.Base64;
 
 import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
 
 public class CertificateValidationUtil {
 
     private static Log log = LogFactory.getLog(CertificateValidationUtil.class);
+    private static final String BC = "BC";
 
-    public static List<RevocationValidator> loadValidatorConfig() throws CertificateValidationException {
+    /**
+     * ********************************************
+     * Util methods for Validator Configurations
+     * ********************************************
+     */
+    public static void addDefaultValidationConfigInRegistry(String tenantDomain) {
+        String configFilePath = CarbonUtils.getCarbonConfigDirPath() + File.separator +
+                X509CertificateValidationConstants.CERT_VALIDATION_CONF_DIRECTORY + File.separator +
+                X509CertificateValidationConstants.CERT_VALIDATION_CONF_FILE;
+
+        if (tenantDomain == null) {
+            tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        }
+
+        File configFile = new File(configFilePath);
+        if (!configFile.exists()) {
+            log.error("Certification validation Configuration File is not present at: " + configFilePath);
+            return;
+        }
+
+        XMLStreamReader xmlStreamReader = null;
+        InputStream inputStream = null;
+        try {
+            inputStream = new FileInputStream(configFile);
+            StAXOMBuilder builder = new StAXOMBuilder(inputStream);
+
+            OMElement documentElement = builder.getDocumentElement();
+            Iterator iterator = documentElement.getChildElements();
+            while (iterator.hasNext()) {
+                OMElement childElement = (OMElement) iterator.next();
+                if (childElement.getLocalName().equals(X509CertificateValidationConstants.VALIDATOR_CONF)) {
+                    addDefaultValidatorConfig(childElement, tenantDomain);
+                } else if(childElement.getLocalName().equals(X509CertificateValidationConstants.TRUSTSTORE_CONF)) {
+                    addDefaultCACertificates(childElement, tenantDomain);
+                }
+            }
+        } catch (XMLStreamException | FileNotFoundException e) {
+            log.warn("Error while loading default validator configurations to the registry.", e);
+        } finally {
+            try {
+                if (xmlStreamReader != null) {
+                    xmlStreamReader.close();
+                }
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (XMLStreamException e) {
+                log.error("Error while closing XML stream", e);
+            } catch (IOException e) {
+                log.error("Error while closing input stream", e);
+            }
+        }
+    }
+
+    public static List<RevocationValidator> loadValidatorConfigFromRegistry() throws CertificateValidationException {
+        if(log.isDebugEnabled()) {
+            log.debug("Loading X509 certificate validator configurations from registry.");
+        }
         String validatorConfRegPath = X509CertificateValidationConstants.VALIDATOR_CONF_REG_PATH;
         List<RevocationValidator> validators = new ArrayList<>();
 
@@ -82,6 +149,8 @@ public class CertificateValidationUtil {
                         }
                         revocationValidator.setEnable(validator.getEnabled());
                         revocationValidator.setPriority(validator.getPriority());
+                        revocationValidator.setFullChainValidation(validator.getFullChainValidationEnabled());
+                        revocationValidator.setRetryCount(validator.getRetryCount());
                         validators.add(revocationValidator);
                     }
                 }
@@ -92,11 +161,269 @@ public class CertificateValidationUtil {
         return validators;
     }
 
-    public static void addDefaultValidatorConfig(String tenantDomain) {
-        if(tenantDomain == null) {
-            tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+    /**
+     * ****************************************
+     * Util methods for CA Cert Configuration
+     * ****************************************
+     */
+    private static void addDefaultCACertificates(OMElement trustStoresElement, String tenantDomain) {
+        try {
+            Iterator trustStoreIterator = trustStoresElement.getChildElements();
+            Registry registry = getGovernanceRegistry(tenantDomain);
+            List<X509Certificate> trustedCertificates = new ArrayList<>();
+
+            while (trustStoreIterator.hasNext()) {
+                OMElement trustStoreElement = (OMElement) trustStoreIterator.next();
+                String trustStoreFile = trustStoreElement.getAttributeValue(
+                        new QName(X509CertificateValidationConstants.TRUSTSTORE_CONF_FILE));
+                String trustStorePassword = trustStoreElement.getAttributeValue(
+                        new QName(X509CertificateValidationConstants.TRUSTSTORE_CONF_PASSWORD));
+
+                KeyStore keyStore = CertificateValidationUtil.loadKeyStoreFromFile(trustStoreFile, trustStorePassword, null);
+                try {
+                    trustedCertificates.addAll(CertificateValidationUtil.exportCertificateChainFromKeyStore(keyStore));
+                } catch (KeyStoreException e) {
+                    log.error("Error while exporting certificate chain from trust store.", e);
+                }
+            }
+
+            for(X509Certificate certificate :  trustedCertificates) {
+                String caCertRegPath = X509CertificateValidationConstants.CA_CERT_REG_PATH +
+                        PATH_SEPARATOR +
+                        URLEncoder.encode(getNormalizedName(certificate.getSubjectDN().getName()), "UTF-8").
+                                replaceAll("%", ":") + PATH_SEPARATOR +
+                        getNormalizedName(certificate.getSerialNumber().toString());
+
+                if (!registry.resourceExists(caCertRegPath)) {
+                    addDefaultCACertificateInRegistry(registry, caCertRegPath, certificate);
+                }
+            }
+
+        } catch (RegistryException | UnsupportedEncodingException | CertificateValidationException e) {
+            log.error("Error while adding validator configurations in registry.", e);
         }
-        List<Validator> defaultValidatorConfig = getDefaultValidatorConfig();
+    }
+
+    public static List<CACertificate> loadCaCertsFromRegistry(X509Certificate peerCertificate)
+            throws CertificateValidationException {
+
+        List<CACertificate> caCertificateList = new ArrayList<>();
+        try {
+            String caRegPath = X509CertificateValidationConstants.CA_CERT_REG_PATH +
+                    PATH_SEPARATOR + URLEncoder.encode(getNormalizedName(peerCertificate.getIssuerDN().getName()), "UTF-8").
+                    replaceAll("%", ":");
+
+            //get tenant registry for loading validator configurations
+            Registry registry = getGovernanceRegistry(
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+            if (registry.resourceExists(caRegPath)) {
+                Collection collection = (Collection) registry.get(caRegPath);
+                if (collection != null) {
+                    String[] children = collection.getChildren();
+                    for (String child : children) {
+                        Resource resource = registry.get(child);
+                        CACertificate caCertificate = resourceToCACertObject(resource);
+                        caCertificateList.add(caCertificate);
+                    }
+                }
+            }
+        } catch (RegistryException | UnsupportedEncodingException e) {
+            throw new CertificateValidationException("Error while loading validator configurations from registry.", e);
+        }
+        return caCertificateList;
+    }
+
+
+    /**
+     * **********************************
+     * Util Methods for CRL Validation
+     * **********************************
+     */
+    /**
+     * Extracts all CRL distribution point URLs from the "CRL Distribution Point"
+     * extension in a X.509 certificate. If CRL distribution point extension is
+     * unavailable, returns an empty list.
+     */
+    public static List<String> getCrlDistributionPoints(X509Certificate cert)
+            throws CertificateValidationException {
+        List<String> crlUrls = new ArrayList<>();
+
+        //Gets the DER-encoded OCTET string for the extension value for CRLDistributionPoints
+        byte[] crlDPExtensionValue = cert.getExtensionValue(org.bouncycastle.asn1.x509.Extension.cRLDistributionPoints.getId());
+        if (crlDPExtensionValue == null) {
+            log.error("Certificate doesn't have CRL Distribution points");
+            return crlUrls;
+        }
+        //crlDPExtensionValue is encoded in ASN.1 format.
+        ASN1InputStream asn1In = new ASN1InputStream(crlDPExtensionValue);
+        //DER (Distinguished Encoding Rules) is one of ASN.1 encoding rules defined in ITU-T X.690, 2002, specification.
+        //ASN.1 encoding rules can be used to encode any data object into a binary file. Read the object in octets.
+        CRLDistPoint distPoint;
+        try {
+            DEROctetString crlDEROctetString = (DEROctetString) asn1In.readObject();
+            //Get Input stream in octets
+            ASN1InputStream asn1InOctets = new ASN1InputStream(crlDEROctetString.getOctets());
+            ASN1Primitive crlDERObject = asn1InOctets.readObject();
+            distPoint = CRLDistPoint.getInstance(crlDERObject);
+        } catch (IOException e) {
+            throw new CertificateValidationException("Cannot read certificate to get CRL urls", e);
+        }
+
+        //Loop through ASN1Encodable DistributionPoints
+        for (DistributionPoint dp : distPoint.getDistributionPoints()) {
+            //get ASN1Encodable DistributionPointName
+            DistributionPointName dpn = dp.getDistributionPoint();
+            if (dpn != null && dpn.getType() == DistributionPointName.FULL_NAME) {
+                //Create ASN1Encodable General Names
+                GeneralName[] genNames = GeneralNames.getInstance(dpn.getName()).getNames();
+                // Look for a URI
+                //todo: May be able to check for OCSP url specifically.
+                for (GeneralName genName : genNames) {
+                    if (genName.getTagNo() == GeneralName.uniformResourceIdentifier) {
+                        //DERIA5String contains an ascii string.
+                        //A IA5String is a restricted character string type in the ASN.1 notation
+                        String url = DERIA5String.getInstance(genName.getName()).getString().trim();
+                        crlUrls.add(url);
+                    }
+                }
+            }
+        }
+        if (crlUrls.isEmpty()) {
+            throw new CertificateValidationException("Cant get CRL urls from certificate");
+        }
+        return crlUrls;
+    }
+
+
+    /**
+     * **************************************
+     * Util Methods for OCSP Validation
+     * **************************************
+     */
+
+    public static X509Certificate loadCaCertFromTrustStore(X509Certificate peerCertificate)
+            throws CertificateValidationException {
+        X509Certificate caCertificate = null;
+        String configFilePath = CarbonUtils.getCarbonConfigDirPath() + File.separator +
+                X509CertificateValidationConstants.CERT_VALIDATION_CONF_DIRECTORY + File.separator +
+                X509CertificateValidationConstants.CERT_VALIDATION_CONF_FILE;
+
+        File configFile = new File(configFilePath);
+        if (!configFile.exists()) {
+            throw new CertificateValidationException("Certification validation Configuration File is not present at: "
+                    + configFilePath);
+        }
+
+        XMLStreamReader xmlStreamReader = null;
+        InputStream inputStream = null;
+        try {
+            inputStream = new FileInputStream(configFile);
+            StAXOMBuilder builder = new StAXOMBuilder(inputStream);
+
+            OMElement documentElement = builder.getDocumentElement();
+            Iterator iterator = documentElement.getChildElements();
+            while (iterator.hasNext()) {
+                OMElement childElement = (OMElement) iterator.next();
+                if(childElement.getLocalName().equals(X509CertificateValidationConstants.TRUSTSTORE_CONF)) {
+                    Iterator trustStoreIterator = childElement.getChildElements();
+                    List<X509Certificate> trustedCertificates = new ArrayList<>();
+
+                    while (trustStoreIterator.hasNext()) {
+                        OMElement trustStoreElement = (OMElement) trustStoreIterator.next();
+                        String trustStoreFile = trustStoreElement.getAttributeValue(
+                                new QName(X509CertificateValidationConstants.TRUSTSTORE_CONF_FILE));
+                        String trustStorePassword = trustStoreElement.getAttributeValue(
+                                new QName(X509CertificateValidationConstants.TRUSTSTORE_CONF_PASSWORD));
+                        String type = trustStoreElement.getAttributeValue(
+                                new QName(X509CertificateValidationConstants.TRUSTSTORE_CONF_TYPE));
+
+                        KeyStore keyStore = CertificateValidationUtil.loadKeyStoreFromFile(trustStoreFile,
+                                trustStorePassword, type);
+                        try {
+                            trustedCertificates.addAll(CertificateValidationUtil.exportCertificateChainFromKeyStore
+                                    (keyStore));
+                        } catch (KeyStoreException e) {
+                            throw new CertificateValidationException("Error when exporting CA certificates from " +
+                                    "trust store");
+                        }
+                    }
+
+                    for(X509Certificate certificate :  trustedCertificates) {
+                        if(certificate.getSubjectX500Principal().equals(peerCertificate.getIssuerX500Principal())){
+                            caCertificate = certificate;
+                        }
+                    }
+                }
+            }
+        } catch (XMLStreamException | FileNotFoundException e) {
+            log.warn("Error while loading default CA certificates from trust stores.", e);
+        } finally {
+            try {
+                if (xmlStreamReader != null) {
+                    xmlStreamReader.close();
+                }
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (XMLStreamException e) {
+                log.error("Error while closing XML stream", e);
+            } catch (IOException e) {
+                log.error("Error while closing input stream", e);
+            }
+        }
+        return caCertificate;
+
+    }
+
+    /**
+     * Authority Information Access (AIA) is a non-critical extension in an X509 Certificate. This contains the
+     * URL of the OCSP endpoint if one is available.
+     * TODO: This might contain non OCSP urls as well. Handle this.
+     *
+     * @param cert is the certificate
+     * @return a lit of URLs in AIA extension of the certificate which will hopefully contain an OCSP endpoint.
+     * @throws CertificateValidationException
+     *
+     */
+    public static List<String> getAIALocations(X509Certificate cert) throws CertificateValidationException {
+        List<String> ocspUrlList = new ArrayList<String>();
+
+        //Gets the DER-encoded OCTET string for the extension value for Authority information access Points
+        byte[] aiaExtensionValue = cert.getExtensionValue(Extension.authorityInfoAccess.getId());
+        if (aiaExtensionValue == null) {
+            log.error("Certificate Doesn't have Authority Information Access points");
+            return ocspUrlList;
+        }
+        AuthorityInformationAccess authorityInformationAccess;
+
+        try {
+            DEROctetString oct = (DEROctetString) (new ASN1InputStream(new ByteArrayInputStream(aiaExtensionValue)).readObject());
+            authorityInformationAccess = AuthorityInformationAccess.getInstance(new ASN1InputStream(oct.getOctets()).readObject());
+        } catch (IOException e) {
+            throw new CertificateValidationException("Cannot read certificate to get OSCP urls", e);
+        }
+
+        AccessDescription[] accessDescriptions = authorityInformationAccess.getAccessDescriptions();
+        for (AccessDescription accessDescription : accessDescriptions) {
+
+            GeneralName gn = accessDescription.getAccessLocation();
+            if (gn.getTagNo() == GeneralName.uniformResourceIdentifier) {
+                DERIA5String str = DERIA5String.getInstance(gn.getName());
+                String accessLocation = str.getString();
+                ocspUrlList.add(accessLocation);
+            }
+        }
+        if(ocspUrlList.isEmpty())
+            throw new CertificateValidationException("Cant get OCSP urls from certificate");
+
+        return ocspUrlList;
+    }
+
+
+
+    private static void addDefaultValidatorConfig(OMElement validatorsElement, String tenantDomain) {
+
+        List<Validator> defaultValidatorConfig = getDefaultValidatorConfig(validatorsElement);
 
         // iterate through the validator config list and write to the the registry
         for (Validator validator : defaultValidatorConfig) {
@@ -117,62 +444,34 @@ public class CertificateValidationUtil {
         }
     }
 
-    public static List<Validator> getDefaultValidatorConfig() {
-        String configFilePath = CarbonUtils.getCarbonConfigDirPath() + File.separator +
-                X509CertificateValidationConstants.VALIDATOR_CONF_DIRECTORY + File.separator +
-                X509CertificateValidationConstants.VALIDATOR_CONF_FILE;
-
+    private static List<Validator> getDefaultValidatorConfig(OMElement validatorsElement) {
         List<Validator> defaultValidatorConfig = new ArrayList<>();
-        File configFile = new File(configFilePath);
-        if (!configFile.exists()) {
-            log.error("Certification validator Configuration File is not present at: " + configFilePath);
+        Iterator validatorIterator = validatorsElement.getChildElements();
+        while(validatorIterator.hasNext()) {
+            OMElement validatorElement = (OMElement) validatorIterator.next();
+            String name = validatorElement.getAttributeValue(
+                    new QName(X509CertificateValidationConstants.VALIDATOR_CONF_NAME));
+            String displayName = validatorElement.getAttributeValue(
+                    new QName(X509CertificateValidationConstants.VALIDATOR_CONF_DISPLAY_NAME));
+            String enable = validatorElement.getAttributeValue(
+                    new QName(X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE));
+
+            Map<String, String> validatorProperties = getValidatorProperties(validatorElement);
+            String priority = validatorProperties.get(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY);
+            String fullChainValidation = validatorProperties.get(
+                    X509CertificateValidationConstants.VALIDATOR_CONF_FULL_CHAIN_VALIDATION);
+            String retryCount = validatorProperties.get(X509CertificateValidationConstants.VALIDATOR_CONF_RETRY_COUNT);
+
+            Validator validator = new Validator();
+            validator.setName(name);
+            validator.setDisplayName(displayName);
+            validator.setEnabled(Boolean.parseBoolean(enable));
+            validator.setPriority(Integer.parseInt(priority));
+            validator.setFullChainValidationEnabled(Boolean.parseBoolean(fullChainValidation));
+            validator.setRetryCount(Integer.parseInt(retryCount));
+
+            defaultValidatorConfig.add(validator);
         }
-
-        XMLStreamReader xmlStreamReader = null;
-        InputStream inputStream = null;
-        try {
-            inputStream = new FileInputStream(configFile);
-            StAXOMBuilder builder = new StAXOMBuilder(inputStream);
-
-            OMElement documentElement = builder.getDocumentElement();
-            Iterator iterator = documentElement.getChildElements();
-            while (iterator.hasNext()) {
-                OMElement omElement = (OMElement) iterator.next();
-                String name = omElement.getAttributeValue(
-                        new QName(X509CertificateValidationConstants.VALIDATOR_CONF_NAME));
-                String displayName = omElement.getAttributeValue(
-                        new QName(X509CertificateValidationConstants.VALIDATOR_CONF_DISPLAY_NAME));
-                String enable = omElement.getAttributeValue(
-                        new QName(X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE));
-
-                Map<String, String> validatorProperties = getValidatorProperties(omElement);
-                String priority = validatorProperties.get(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY);
-
-                Validator validator = new Validator();
-                validator.setName(name);
-                validator.setDisplayName(displayName);
-                validator.setEnabled(Boolean.parseBoolean(enable));
-                validator.setPriority(Integer.parseInt(priority));
-
-                defaultValidatorConfig.add(validator);
-            }
-        } catch (XMLStreamException | FileNotFoundException e) {
-            log.warn("Error while loading default validator configurations to the registry.", e);
-        } finally {
-            try {
-                if (xmlStreamReader != null) {
-                    xmlStreamReader.close();
-                }
-                if (inputStream != null) {
-                    inputStream.close();
-                }
-            } catch (XMLStreamException e) {
-                log.error("Error while closing XML stream", e);
-            } catch (IOException e) {
-                log.error("Error while closing input stream", e);
-            }
-        }
-
         return defaultValidatorConfig;
     }
 
@@ -184,26 +483,140 @@ public class CertificateValidationUtil {
                 Boolean.toString(validator.getEnabled()));
         resource.addProperty(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY,
                 Integer.toString(validator.getPriority()));
+        resource.addProperty(X509CertificateValidationConstants.VALIDATOR_CONF_FULL_CHAIN_VALIDATION,
+                Boolean.toString(validator.getFullChainValidationEnabled()));
+        resource.addProperty(X509CertificateValidationConstants.VALIDATOR_CONF_RETRY_COUNT,
+                Integer.toString(validator.getRetryCount()));
         registry.put(validatorConfRegPath, resource);
     }
 
     private static Map<String, String> getValidatorProperties(OMElement validatorElement) {
         Map<String, String> validatorProperties = new HashMap<>();
         Iterator it = validatorElement.getChildElements();
+        //read the properties in the validator element
         while (it.hasNext()) {
-            OMElement element = (OMElement) it.next();
-            String elementName = element.getLocalName();
-            String elementText = element.getText();
-            if (StringUtils.equalsIgnoreCase(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY, elementName)) {
-                validatorProperties.put(X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY, elementText);
+            OMElement validatorParamElement = (OMElement) it.next();
+            if (validatorParamElement != null) {
+                String attributeName = validatorParamElement.getAttributeValue(new QName(
+                X509CertificateValidationConstants.VALIDATOR_CONF_ELEMENT_PROPERTY_NAME));
+                String attributeValue = validatorParamElement.getText();
+                validatorProperties.put(attributeName, attributeValue);
             }
         }
         return validatorProperties;
     }
 
+    private static Validator resourceToValidatorObject(Resource resource) {
+        Validator validator = new Validator();
+        validator.setName(resource.getProperty(X509CertificateValidationConstants.VALIDATOR_CONF_NAME));
+        validator.setEnabled(Boolean.parseBoolean(resource.getProperty(
+                X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE)));
+        validator.setPriority(Integer.parseInt(resource.getProperty(
+                X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY)));
+        validator.setFullChainValidationEnabled(Boolean.parseBoolean(resource.getProperty(
+                X509CertificateValidationConstants.VALIDATOR_CONF_FULL_CHAIN_VALIDATION)));
+        validator.setRetryCount(Integer.parseInt(resource.getProperty(
+                X509CertificateValidationConstants.VALIDATOR_CONF_RETRY_COUNT)));
+        return validator;
+    }
+
+    private static CACertificate resourceToCACertObject(Resource resource) throws CertificateValidationException {
+        List<String> crlUrls;
+        List<String> ocspUrls;
+        X509Certificate x509Certificate;
+        try {
+            String crlUrlReg = resource.getProperty(X509CertificateValidationConstants.CA_CERT_REG_CRL);
+            String ocspUrlReg = resource.getProperty(X509CertificateValidationConstants.CA_CERT_REG_OCSP);
+            crlUrls = Arrays.asList(crlUrlReg.split(
+                    X509CertificateValidationConstants.CA_CERT_REG_CRL_OCSP_SEPERATOR));
+            ocspUrls = Arrays.asList(ocspUrlReg.split(
+                    X509CertificateValidationConstants.CA_CERT_REG_CRL_OCSP_SEPERATOR));
+            byte[] regContent = (byte[]) resource.getContent();
+            x509Certificate = decodeCertificate(new String(regContent));
+        } catch (RegistryException | CertificateException e) {
+            throw new CertificateValidationException("Error when converting registry resource content.");
+        }
+        return new CACertificate(crlUrls, ocspUrls, x509Certificate);
+    }
+
+    private static void addDefaultCACertificateInRegistry(Registry registry, String caCertRegPath,
+                                                          X509Certificate certificate)
+            throws CertificateValidationException {
+        try {
+            if (!registry.resourceExists(caCertRegPath)) {
+                Resource resource = registry.newResource();
+                List<String> crlUrls = getCrlDistributionPoints(certificate);
+                StringBuilder crlUrlReg = new StringBuilder();
+                if (CollectionUtils.isNotEmpty(crlUrls)) {
+                    for (String crlUrl : crlUrls) {
+                        crlUrlReg.append(crlUrl).append(X509CertificateValidationConstants.CA_CERT_REG_CRL_OCSP_SEPERATOR);
+                    }
+                }
+
+                List<String> ocspUrls = getAIALocations(certificate);
+                StringBuilder ocspUrlReg = new StringBuilder();
+                if (CollectionUtils.isNotEmpty(ocspUrls)) {
+                    for (String ocspUrl : ocspUrls) {
+                        ocspUrlReg.append(ocspUrl).append(X509CertificateValidationConstants.CA_CERT_REG_CRL_OCSP_SEPERATOR);
+                    }
+                }
+                resource.addProperty(X509CertificateValidationConstants.CA_CERT_REG_CRL, crlUrlReg.toString());
+                resource.addProperty(X509CertificateValidationConstants.CA_CERT_REG_OCSP, ocspUrlReg.toString());
+                resource.setContent(encodeCertificate(certificate));
+                registry.put(caCertRegPath, resource);
+            }
+        } catch (RegistryException e) {
+            throw new CertificateValidationException("Error adding default ca certificate in registry.", e);
+        } catch (CertificateException e) {
+            throw new CertificateValidationException("Error encoding ca certificate to add in registry.", e);
+        }
+    }
+
+    /**
+     * Generic Util Methods
+     */
+
+    private static KeyStore loadKeyStoreFromFile(String keyStorePath, String password, String type) {
+        if(type == null) {
+            type = X509CertificateValidationConstants.TRUSTSTORE_CONF_TYPE_DEFAULT;
+        }
+        CarbonUtils.checkSecurity();
+        String absolutePath = new File(keyStorePath).getAbsolutePath();
+        FileInputStream inputStream = null;
+        try {
+            KeyStore store = KeyStore.getInstance(type);
+            inputStream = new FileInputStream(absolutePath);
+            store.load(inputStream, password.toCharArray());
+            return store;
+        } catch (Exception e) {
+            String errorMsg = "Error loading the key store from the given location.";
+            log.error(errorMsg);
+            throw new SecurityException(errorMsg, e);
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+                log.warn("Error when closing the input stream.", e);
+            }
+        }
+    }
+
+    private static List<X509Certificate> exportCertificateChainFromKeyStore(KeyStore keyStore) throws KeyStoreException {
+        Enumeration<String> aliases =  keyStore.aliases();
+        List<X509Certificate> certificates = new ArrayList<>();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            certificates.add((X509Certificate) keyStore.getCertificate(alias));
+        }
+        return certificates;
+    }
+
     private static String getNormalizedName(String name) {
         if (StringUtils.isNotBlank(name)) {
             return name.replaceAll("\\s+", "").toLowerCase();
+            //~!@#;%^*+={}|<>,\\'\\\\"\\\\\\\\()[]
         }
         throw new IllegalArgumentException("Invalid validator name provided : " + name);
     }
@@ -215,18 +628,108 @@ public class CertificateValidationUtil {
             registry = CertValidationDataHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(
                     CertValidationDataHolder.getInstance().getRealmService().getTenantManager().getTenantId(tenantDomain));
         } catch (UserStoreException | RegistryException e) {
-            throw new CertificateValidationException("Error while get tenant registry." , e);
+            throw new CertificateValidationException("Error while get tenant registry.", e);
         }
         return registry;
     }
 
-    private static Validator resourceToValidatorObject(Resource resource) {
-        Validator validator = new Validator();
-        validator.setName(resource.getProperty(X509CertificateValidationConstants.VALIDATOR_CONF_NAME));
-        validator.setEnabled(Boolean.parseBoolean(resource.getProperty(
-                X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE)));
-        validator.setPriority(Integer.parseInt(resource.getProperty(
-                X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY)));
-        return validator;
+/*    *//**
+     * Converts a X509Certificate instance into a Base-64 encoded string (PEM format).
+     *
+     * @param x509Cert A X509 Certificate instance
+     * @return PEM formatted String
+     * @throws IOException
+     *//*
+    private static String convertX509CertToBase64PEMString(X509Certificate x509Cert) throws IOException {
+        StringWriter sw = new StringWriter();
+        try (PEMWriter pw = new PEMWriter(sw)) {
+            pw.writeObject(x509Cert);
+        }
+        return sw.toString();
     }
+
+    private static String convertX509CertToBase64(X509Certificate x509Cert) throws IOException {
+        StringWriter sw = new StringWriter();
+        try {
+            sw.write("-----BEGIN CERTIFICATE-----\n");
+            sw.write(DatatypeConverter.printBase64Binary(x509Cert.getEncoded()).replaceAll("(.{64})", "$1\n"));
+            sw.write("\n-----END CERTIFICATE-----\n");
+        } catch (CertificateEncodingException e) {
+            e.printStackTrace();
+        }
+        return sw.toString();
+    }
+
+    *//**
+     * Converts a PEM formatted String to a X509Certificate instance.
+     *
+     * @param pem PEM formatted String
+     * @return a X509Certificate instance
+     * @throws CertificateException
+     * @throws IOException
+     *//*
+    public static X509Certificate convertBase64PEMToX509Certificate(String pem) throws IOException {
+        StringReader reader = new StringReader(pem);
+        PEMReader pr = new PEMReader(reader);
+        X509Certificate x509Cert = (X509Certificate)pr.readObject();
+        return x509Cert;
+    }
+
+    public static X509Certificate convertToX509Cert(String certificateString) throws CertificateValidationException {
+        X509Certificate certificate = null;
+        CertificateFactory cf = null;
+        try {
+            if (certificateString != null && !certificateString.trim().isEmpty()) {
+                certificateString = certificateString.replace("-----BEGIN CERTIFICATE-----\n", "")
+                        .replace("-----END CERTIFICATE-----", ""); // NEED FOR PEM FORMAT CERT STRING
+                byte[] certificateData = Base64.getDecoder().decode(certificateString);
+                cf = CertificateFactory.getInstance("X509");
+                certificate = (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(certificateData));
+            }
+        } catch (CertificateException e) {
+            throw new CertificateValidationException(e);
+        }
+        return certificate;
+    }*/
+
+    /**
+     * Generate thumbprint of certificate
+     *
+     * @param encodedCert Base64 encoded certificate
+     * @return Decoded <code>Certificate</code>
+     * @throws java.security.cert.CertificateException Error when decoding certificate
+     */
+    public static X509Certificate decodeCertificate(String encodedCert) throws CertificateException {
+
+        if (encodedCert != null) {
+            byte[] bytes = Base64.decode(encodedCert);
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            X509Certificate cert = (X509Certificate) factory
+                    .generateCertificate(new ByteArrayInputStream(bytes));
+            return cert;
+        } else {
+            String errorMsg = "Invalid encoded certificate: \'NULL\'";
+            log.debug(errorMsg);
+            throw new IllegalArgumentException(errorMsg);
+        }
+    }
+
+    /**
+     * Generate thumbprint of certificate
+     *
+     * @param encodedCert Base64 encoded certificate
+     * @return Decoded <code>Certificate</code>
+     * @throws java.security.cert.CertificateException Error when decoding certificate
+     */
+    public static String encodeCertificate(X509Certificate certificate) throws CertificateException {
+
+        if (certificate != null) {
+            return Base64.encode(certificate.getEncoded());
+        } else {
+            String errorMsg = "Invalid encoded certificate: \'NULL\'";
+            log.debug(errorMsg);
+            throw new IllegalArgumentException(errorMsg);
+        }
+    }
+
 }

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/RevocationStatus.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/RevocationStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation;
+
+public enum RevocationStatus {
+
+    GOOD("Good"), UNKNOWN("Unknown"), REVOKED("Revoked");
+    private String message;
+
+    private RevocationStatus(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation;
+
+/**
+ * X509 Certificate validation constants.
+ */
+public class X509CertificateValidationConstants {
+
+    private X509CertificateValidationConstants() {
+    }
+
+    public static final String VALIDATOR_CONF_DIRECTORY = "security";
+    public static final String VALIDATOR_CONF_FILE = "certificate-validators.xml";
+    public static final String VALIDATOR_CONF_NAME = "name";
+    public static final String VALIDATOR_CONF_DISPLAY_NAME = "displayName";
+    public static final String VALIDATOR_CONF_ENABLE = "enable";
+    public static final String VALIDATOR_CONF_PRIORITY = "priority";
+    public static final String VALIDATOR_CONF_REG_PATH = "repository/security/certificate/validator";
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -26,11 +26,27 @@ public class X509CertificateValidationConstants {
     private X509CertificateValidationConstants() {
     }
 
-    public static final String VALIDATOR_CONF_DIRECTORY = "security";
-    public static final String VALIDATOR_CONF_FILE = "certificate-validators.xml";
+    public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";
+    public static final String CERT_VALIDATION_CONF_FILE = "certificate-validation.xml";
+
+    public static final String VALIDATOR_CONF = "Validators";
     public static final String VALIDATOR_CONF_NAME = "name";
     public static final String VALIDATOR_CONF_DISPLAY_NAME = "displayName";
     public static final String VALIDATOR_CONF_ENABLE = "enable";
     public static final String VALIDATOR_CONF_PRIORITY = "priority";
+    public static final String VALIDATOR_CONF_ELEMENT_PARAMETER = "Parameter";
+    public static final String VALIDATOR_CONF_ELEMENT_PROPERTY_NAME = "name";
+    public static final String VALIDATOR_CONF_FULL_CHAIN_VALIDATION = "fullChainValidation";
+    public static final String VALIDATOR_CONF_RETRY_COUNT = "retryCount";
     public static final String VALIDATOR_CONF_REG_PATH = "repository/security/certificate/validator";
+
+    public static final String TRUSTSTORE_CONF = "TrustStores";
+    public static final String TRUSTSTORE_CONF_FILE = "truststoreFile";
+    public static final String TRUSTSTORE_CONF_PASSWORD = "truststorePass";
+    public static final String TRUSTSTORE_CONF_TYPE = "type";
+    public static final String TRUSTSTORE_CONF_TYPE_DEFAULT = "JKS";
+    public static final String CA_CERT_REG_PATH = "repository/security/certificate/certificate-authority";
+    public static final String CA_CERT_REG_CRL = "crl";
+    public static final String CA_CERT_REG_OCSP = "ocsp";
+    public static final String CA_CERT_REG_CRL_OCSP_SEPERATOR = ",";
 }

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/cache/CRLCache.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/cache/CRLCache.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.cache;
+
+import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * CRLCache with X509CRL entries against CRL URLs
+ */
+public class CRLCache extends BaseCache<String, CRLCacheEntry> {
+
+    private static final String CRL_CACHE_NAME = "CRLCache";
+
+    private static volatile CRLCache instance;
+
+    private CRLCache() {
+        super(CRL_CACHE_NAME);
+    }
+
+    public static CRLCache getInstance() {
+        CarbonUtils.checkSecurity();
+        if (instance == null) {
+            synchronized (CRLCache.class) {
+                if (instance == null) {
+                    instance = new CRLCache();
+                }
+            }
+        }
+        return instance;
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/cache/CRLCache.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/cache/CRLCache.java
@@ -18,7 +18,9 @@
 
 package org.wso2.carbon.identity.x509Certificate.validation.cache;
 
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 
 /**
@@ -44,5 +46,17 @@ public class CRLCache extends BaseCache<String, CRLCacheEntry> {
             }
         }
         return instance;
+    }
+
+    public void addToCache(String key, CRLCacheEntry crlCacheEntry) {
+        super.addToCache(key, crlCacheEntry);
+    }
+
+    public CRLCacheEntry getValueFromCache(String key) {
+        return super.getValueFromCache(key);
+    }
+
+    public void clearCacheEntry(String key) {
+        super.clearCacheEntry(key);
     }
 }

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/cache/CRLCacheEntry.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/cache/CRLCacheEntry.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.cache;
+
+import java.io.Serializable;
+import java.security.cert.X509CRL;
+
+public class CRLCacheEntry implements Serializable {
+
+    private static final long serialVersionUID = 1591693579088522864L;
+
+    private X509CRL x509CRL;
+
+    public X509CRL getX509CRL() {
+        return x509CRL;
+    }
+
+    public void setX509CRL(X509CRL x509CRL) {
+        this.x509CRL = x509CRL;
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.internal;
+
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.user.core.service.RealmService;
+
+public class CertValidationDataHolder {
+
+    private static RegistryService registryService;
+    private static RealmService realmService;
+    private static CertValidationDataHolder instance = new CertValidationDataHolder();
+
+    private CertValidationDataHolder() {
+    }
+
+    public static CertValidationDataHolder getInstance() {
+        return instance;
+    }
+
+    public RegistryService getRegistryService() {
+        return registryService;
+    }
+
+    public void setRegistryService(RegistryService service) {
+        registryService = service;
+    }
+
+    public void unsetRegistryService() {
+        registryService = null;
+    }
+
+    public void setRealmService(RealmService realmService) {
+        CertValidationDataHolder.realmService = realmService;
+    }
+
+    public RealmService getRealmService() {
+        return realmService;
+    }
+
+    public void unsetRealmService() {
+        realmService = null;
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/TenantManagementListener.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/TenantManagementListener.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
+import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
+import org.wso2.carbon.stratos.common.exception.StratosException;
+import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+
+public class TenantManagementListener implements TenantMgtListener {
+
+    private static final int EXEC_ORDER = 22;
+    private static Log log = LogFactory.getLog(TenantManagementListener.class);
+
+    public void onTenantCreate(TenantInfoBean tenantInfo) throws StratosException {
+        String tenantDomain = tenantInfo.getTenantDomain();
+        CertificateValidationUtil.addDefaultValidatorConfig(tenantDomain);
+    }
+
+    public void onTenantUpdate(TenantInfoBean tenantInfo) throws StratosException {
+    }
+
+    @Override
+    public void onPreDelete(int tenantId) throws StratosException {
+    }
+
+    @Override
+    public void onTenantDelete(int i) {
+    }
+
+    public void onTenantRename(int tenantId, String oldDomainName,
+                               String newDomainName) throws StratosException {
+    }
+
+    public int getListenerOrder() {
+        return EXEC_ORDER;
+    }
+
+    public void onTenantInitialActivation(int tenantId) throws StratosException {
+    }
+
+    public void onTenantActivation(int tenantId) throws StratosException {
+    }
+
+    public void onTenantDeactivation(int tenantId) throws StratosException {
+    }
+
+    public void onSubscriptionPlanChange(int tenentId, String oldPlan, String newPlan) throws StratosException {
+    }
+
+}
+

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/TenantManagementListener.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/TenantManagementListener.java
@@ -20,10 +20,15 @@ package org.wso2.carbon.identity.x509Certificate.validation.internal;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
 import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
 import org.wso2.carbon.stratos.common.exception.StratosException;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 public class TenantManagementListener implements TenantMgtListener {
 
@@ -31,8 +36,6 @@ public class TenantManagementListener implements TenantMgtListener {
     private static Log log = LogFactory.getLog(TenantManagementListener.class);
 
     public void onTenantCreate(TenantInfoBean tenantInfo) throws StratosException {
-        String tenantDomain = tenantInfo.getTenantDomain();
-        CertificateValidationUtil.addDefaultValidatorConfig(tenantDomain);
     }
 
     public void onTenantUpdate(TenantInfoBean tenantInfo) throws StratosException {
@@ -55,6 +58,14 @@ public class TenantManagementListener implements TenantMgtListener {
     }
 
     public void onTenantInitialActivation(int tenantId) throws StratosException {
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext
+                .getThreadLocalCarbonContext();
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
+        carbonContext.setTenantId(tenantId);
+        carbonContext.setTenantDomain(tenantDomain);
+        CertificateValidationUtil.addDefaultValidationConfigInRegistry(tenantDomain);
+        PrivilegedCarbonContext.endTenantFlow();
     }
 
     public void onTenantActivation(int tenantId) throws StratosException {

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
+import org.wso2.carbon.identity.x509Certificate.validation.validator.RevocationValidator;
+import org.wso2.carbon.identity.x509Certificate.validation.validator.CRLValidator;
+import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManager;
+import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManagerImpl;
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * @scr.component name="validation.X509Certificate.service" immediate=true
+ * @scr.reference name="realm.service"
+ * interface="org.wso2.carbon.user.core.service.RealmService"cardinality="1..1"
+ * policy="dynamic" bind="setRealmService" unbind="unsetRealmService"
+ * @scr.reference name="registry.service" interface="org.wso2.carbon.registry.core.service.RegistryService"
+ * cardinality="1..1" policy="dynamic" bind="setRegistryService"
+ * unbind="unsetRegistryService"
+ */
+public class X509CertificateValidationServiceComponent {
+    private static Log log = LogFactory.getLog(X509CertificateValidationServiceComponent.class);
+
+    protected void activate(ComponentContext context) {
+        context.getBundleContext().registerService(RevocationValidationManager.class.getName(),
+                new RevocationValidationManagerImpl(), null);
+        CertificateValidationUtil.addDefaultValidatorConfig(null);
+        context.getBundleContext().registerService(RevocationValidator.class.getName(),
+                new CRLValidator(), null);
+        context.getBundleContext().registerService(TenantMgtListener.class.getName(),
+                new TenantManagementListener(), null);
+    }
+
+    protected void deactivate(ComponentContext componentContext) {
+        if (log.isDebugEnabled()) {
+            log.debug("X509 Certificate Validation bundle is de-activated.");
+        }
+    }
+
+    protected void setRegistryService(RegistryService registryService) {
+        CertValidationDataHolder.getInstance().setRegistryService(registryService);
+    }
+
+    protected void unsetRegistryService(RegistryService registryService) {
+        if (log.isDebugEnabled()) {
+            log.debug("Unset Registry service.");
+        }
+        CertValidationDataHolder.getInstance().unsetRegistryService();
+    }
+
+    protected void setRealmService(RealmService realmService) {
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the Realm Service");
+        }
+        CertValidationDataHolder.getInstance().setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+        if (log.isDebugEnabled()) {
+            log.debug("UnSetting the Realm Service");
+        }
+        CertValidationDataHolder.getInstance().unsetRealmService();
+    }
+
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
+import org.wso2.carbon.identity.x509Certificate.validation.validator.OCSPValidator;
 import org.wso2.carbon.identity.x509Certificate.validation.validator.RevocationValidator;
 import org.wso2.carbon.identity.x509Certificate.validation.validator.CRLValidator;
 import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManager;
@@ -45,9 +46,11 @@ public class X509CertificateValidationServiceComponent {
     protected void activate(ComponentContext context) {
         context.getBundleContext().registerService(RevocationValidationManager.class.getName(),
                 new RevocationValidationManagerImpl(), null);
-        CertificateValidationUtil.addDefaultValidatorConfig(null);
+        CertificateValidationUtil.addDefaultValidationConfigInRegistry(null);
         context.getBundleContext().registerService(RevocationValidator.class.getName(),
                 new CRLValidator(), null);
+        context.getBundleContext().registerService(RevocationValidator.class.getName(),
+                new OCSPValidator(), null);
         context.getBundleContext().registerService(TenantMgtListener.class.getName(),
                 new TenantManagementListener(), null);
     }

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CACertificate.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CACertificate.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+public class CACertificate {
+
+    private List<String> crlUrls;
+    private List<String> ocspUrls;
+    private X509Certificate x509Certificate;
+
+    public CACertificate() {
+
+    }
+
+    public CACertificate(List<String> crlUrls, List<String> ocspUrls, X509Certificate x509Certificate) {
+        this.crlUrls = crlUrls;
+        this.ocspUrls = ocspUrls;
+        this.x509Certificate = x509Certificate;
+    }
+
+    public List<String> getCrlUrl() {
+        return crlUrls;
+    }
+
+    public void setCrlUrl(List<String> crlUrls) {
+        this.crlUrls = crlUrls;
+    }
+
+    public List<String> getOcspUrl() {
+        return ocspUrls;
+    }
+
+    public void setOcspUrl(List<String> ocspUrls) {
+        this.ocspUrls = ocspUrls;
+    }
+
+    public X509Certificate getX509Certificate() {
+        return x509Certificate;
+    }
+
+    public void setX509Certificate(X509Certificate x509Certificate) {
+        this.x509Certificate = x509Certificate;
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/Validator.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/Validator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+public class Validator {
+
+    private String name;
+    private String displayName;
+    private boolean enabled;
+    private int priority;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/Validator.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/Validator.java
@@ -24,6 +24,8 @@ public class Validator {
     private String displayName;
     private boolean enabled;
     private int priority;
+    private boolean fullChainValidationEnabled;
+    private int retryCount;
 
     public String getName() {
         return name;
@@ -55,5 +57,21 @@ public class Validator {
 
     public void setPriority(int priority) {
         this.priority = priority;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+    public void setRetryCount(int retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    public void setFullChainValidationEnabled(boolean fullChainValidationEnabled) {
+        this.fullChainValidationEnabled = fullChainValidationEnabled;
+    }
+
+    public boolean getFullChainValidationEnabled() {
+        return fullChainValidationEnabled;
     }
 }

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/service/RevocationValidationManager.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/service/RevocationValidationManager.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.service;
+
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
+
+import java.security.cert.X509Certificate;
+
+/**
+ * Manager class responsible for validating client certificates. This class will invoke the available validators
+ * based on the configured priorities.
+ */
+public interface RevocationValidationManager {
+
+    boolean verifyRevocationStatus(X509Certificate peerCertificate) throws CertificateValidationException;
+
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/service/RevocationValidationManagerImpl.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/service/RevocationValidationManagerImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.service;
+
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
+import org.wso2.carbon.identity.x509Certificate.validation.RevocationStatus;
+import org.wso2.carbon.identity.x509Certificate.validation.validator.RevocationValidator;
+
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Manager class responsible for validating client certificates. This class will invoke the available validators
+ * based on the configured priorities.
+ */
+public class RevocationValidationManagerImpl implements RevocationValidationManager {
+
+    @Override
+    public boolean verifyRevocationStatus(X509Certificate peerCertificate) throws CertificateValidationException {
+        List<RevocationValidator> revocationValidators = CertificateValidationUtil.loadValidatorConfig();
+        Collections.sort(revocationValidators, revocationValidatorComparator);
+        boolean isRevoked = false;
+
+        for (RevocationValidator validator : revocationValidators) {
+            if (validator.isEnable()) {
+                RevocationStatus revocationStatus = validator.checkRevocationStatus(peerCertificate, null);
+                if (RevocationStatus.REVOKED.equals(revocationStatus)) {
+                    isRevoked = true;
+                }
+            }
+        }
+        return isRevoked;
+    }
+
+    private static Comparator<RevocationValidator> revocationValidatorComparator = new Comparator<RevocationValidator>() {
+
+        @Override
+        public int compare(RevocationValidator revocationValidator1,
+                           RevocationValidator revocationValidator2) {
+            if (revocationValidator1.getPriority() > revocationValidator2.getPriority()) {
+                return 1;
+            } else if (revocationValidator1.getPriority() < revocationValidator2.getPriority()) {
+                return -1;
+            } else {
+                return 0;
+            }
+        }
+    };
+
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/service/RevocationValidationManagerImpl.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/service/RevocationValidationManagerImpl.java
@@ -18,9 +18,12 @@
 
 package org.wso2.carbon.identity.x509Certificate.validation.service;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
 import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
 import org.wso2.carbon.identity.x509Certificate.validation.RevocationStatus;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificate;
 import org.wso2.carbon.identity.x509Certificate.validation.validator.RevocationValidator;
 
 import java.security.cert.X509Certificate;
@@ -34,21 +37,29 @@ import java.util.List;
  */
 public class RevocationValidationManagerImpl implements RevocationValidationManager {
 
+    private static final Log log = LogFactory.getLog(RevocationValidationManagerImpl.class);
+
     @Override
     public boolean verifyRevocationStatus(X509Certificate peerCertificate) throws CertificateValidationException {
-        List<RevocationValidator> revocationValidators = CertificateValidationUtil.loadValidatorConfig();
+        List<RevocationValidator> revocationValidators = CertificateValidationUtil.loadValidatorConfigFromRegistry();
         Collections.sort(revocationValidators, revocationValidatorComparator);
-        boolean isRevoked = false;
+        int validatorCount = revocationValidators.size();
 
         for (RevocationValidator validator : revocationValidators) {
+            --validatorCount;
             if (validator.isEnable()) {
-                RevocationStatus revocationStatus = validator.checkRevocationStatus(peerCertificate, null);
-                if (RevocationStatus.REVOKED.equals(revocationStatus)) {
-                    isRevoked = true;
+                try {
+                    return checkValidity(validator, peerCertificate);
+                } catch (CertificateValidationException e) {
+                    if(validatorCount > 0) {
+                        continue;
+                    } else {
+                        throw e;
+                    }
                 }
             }
         }
-        return isRevoked;
+        return false;
     }
 
     private static Comparator<RevocationValidator> revocationValidatorComparator = new Comparator<RevocationValidator>() {
@@ -65,5 +76,41 @@ public class RevocationValidationManagerImpl implements RevocationValidationMana
             }
         }
     };
+
+    private boolean checkValidity(RevocationValidator validator, X509Certificate certificate)
+            throws CertificateValidationException {
+        log.info("X509 Certificate validation with " + validator.getClass().getName());
+        List<CACertificate> caCertificateList = CertificateValidationUtil.loadCaCertsFromRegistry(certificate);
+        for(CACertificate caCertificate : caCertificateList) {
+            RevocationStatus revocationStatus;
+            try {
+                revocationStatus = validator.checkRevocationStatus(certificate,
+                        caCertificate.getX509Certificate(), validator.getRetryCount());
+            } catch (CertificateValidationException e) {
+                if(log.isDebugEnabled()) {
+                    log.debug("Error when validation certificate revocation with " + validator.getClass().getName() +
+                            ". So check with the next CA certificate in the list.", e);
+                }
+                continue;
+            }
+
+            if(RevocationStatus.UNKNOWN.equals(revocationStatus)) {
+                // indication that the OCSP Responder/CRL URls has no information about the requested certificate.
+                if(log.isDebugEnabled()) {
+                    log.debug("Error when validation certificate revocation with " + validator.getClass().getName() +
+                            ". So check with the next CA certificate in the list.");
+                }
+                continue;
+            } else if (RevocationStatus.REVOKED.equals(revocationStatus)) {
+                return true;
+            } else if(validator.isFullChainValidationEnable() && !caCertificate.getX509Certificate().getIssuerDN().equals
+                    (caCertificate.getX509Certificate().getSubjectDN())) {
+                checkValidity(validator, caCertificate.getX509Certificate());
+            } else if(RevocationStatus.GOOD.equals(revocationStatus)) {
+                return false;
+            }
+        }
+        throw new CertificateValidationException("Cannot check revocation status of the certificate.");
+    }
 
 }

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/validator/CRLValidator.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/validator/CRLValidator.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.validator;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.DERIA5String;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.x509.CRLDistPoint;
+import org.bouncycastle.asn1.x509.DistributionPoint;
+import org.bouncycastle.asn1.x509.DistributionPointName;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
+import org.wso2.carbon.identity.x509Certificate.validation.RevocationStatus;
+import org.wso2.carbon.identity.x509Certificate.validation.cache.CRLCache;
+import org.wso2.carbon.identity.x509Certificate.validation.cache.CRLCacheEntry;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CRLException;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This is used to verify a certificate is revoked or not by using the Certificate Revocation List published
+ * by the CA.
+ */
+public class CRLValidator implements RevocationValidator {
+
+    private static final Log log = LogFactory.getLog(CRLValidator.class);
+    private int priority;
+    private boolean enabled;
+
+    public CRLValidator() {
+    }
+
+    /**
+     * Checks revocation status (Good, Revoked) of the peer certificate. IssuerCertificate can be used
+     * to check if the CRL URL has the Issuers Domain name. But this is not implemented at the moment.
+     *
+     * @param peerCert   peer certificate
+     * @param issuerCert issuer certificate of the peer. not used currently.
+     * @return revocation status of the peer certificate.
+     * @throws org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException
+     */
+    public RevocationStatus checkRevocationStatus(X509Certificate peerCert, X509Certificate issuerCert)
+            throws CertificateValidationException {
+
+        List<String> list = getCrlDistributionPoints(peerCert);
+        //check with distributions points in the list one by one. if one fails go to the other.
+        for (String crlUrl : list) {
+            log.info("Trying to get CRL for URL: " + crlUrl);
+
+            X509CRL x509CRL = null;
+            CRLCacheEntry crlCacheValue = CRLCache.getInstance().getValueFromCache(crlUrl);
+            if(crlCacheValue != null) {
+                x509CRL = crlCacheValue.getX509CRL();
+            }
+            Date currentDate = new Date();
+            try {
+                if (x509CRL != null) {
+                    if (x509CRL.getNextUpdate() != null && currentDate.after(x509CRL.getNextUpdate())) {
+                        log.error("CRL is too old.");
+                        CRLCache.getInstance().clearCacheEntry(crlUrl);
+                    } else {
+                        RevocationStatus status = getRevocationStatus(x509CRL, peerCert);
+                        log.info("CRL taken from cache.");
+                        return status;
+                    }
+                }
+
+                x509CRL = downloadCRLFromWeb(crlUrl);
+                if (x509CRL != null) {
+                    CRLCacheEntry crlCacheEntry = new CRLCacheEntry();
+                    crlCacheEntry.setX509CRL(x509CRL);
+                    CRLCache.getInstance().addToCache(crlUrl, crlCacheEntry);
+                    return getRevocationStatus(x509CRL, peerCert);
+                }
+            } catch (Exception e) {
+                log.info("Either url is bad or cant build X509CRL. So check with the next url in the list.", e);
+            }
+        }
+        throw new CertificateValidationException("Cannot check revocation status with the certificate");
+    }
+
+    @Override
+    public boolean isEnable() {
+        return enabled;
+    }
+
+    @Override
+    public void setEnable(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+
+    @Override
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    private RevocationStatus getRevocationStatus(X509CRL x509CRL, X509Certificate peerCert) {
+        if (x509CRL.isRevoked(peerCert)) {
+            return RevocationStatus.REVOKED;
+        } else {
+            return RevocationStatus.GOOD;
+        }
+    }
+
+    /**
+     * Downloads CRL from the crlUrl. Does not support HTTPS
+     */
+    protected X509CRL downloadCRLFromWeb(String crlURL)
+            throws IOException, CertificateValidationException {
+        InputStream crlStream = null;
+        try {
+            URL url = new URL(crlURL);
+            crlStream = url.openStream();
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            return (X509CRL) cf.generateCRL(crlStream);
+        } catch (MalformedURLException e) {
+            throw new CertificateValidationException("CRL Url is malformed", e);
+        } catch (IOException e) {
+            throw new CertificateValidationException("Cant reach URI: " + crlURL + " - only support HTTP", e);
+        } catch (CertificateException e) {
+            throw new CertificateValidationException(e);
+        } catch (CRLException e) {
+            throw new CertificateValidationException("Cannot generate X509CRL from the stream data", e);
+        } finally {
+            if (crlStream != null)
+                crlStream.close();
+        }
+    }
+
+    /**
+     * Extracts all CRL distribution point URLs from the "CRL Distribution Point"
+     * extension in a X.509 certificate. If CRL distribution point extension is
+     * unavailable, returns an empty list.
+     */
+    private List<String> getCrlDistributionPoints(X509Certificate cert)
+            throws CertificateValidationException {
+
+        //Gets the DER-encoded OCTET string for the extension value for CRLDistributionPoints
+        byte[] crlDPExtensionValue = cert.getExtensionValue(Extension.cRLDistributionPoints.getId());
+        if (crlDPExtensionValue == null)
+            throw new CertificateValidationException("Certificate doesn't have CRL Distribution points");
+        //crlDPExtensionValue is encoded in ASN.1 format.
+        ASN1InputStream asn1In = new ASN1InputStream(crlDPExtensionValue);
+        //DER (Distinguished Encoding Rules) is one of ASN.1 encoding rules defined in ITU-T X.690, 2002, specification.
+        //ASN.1 encoding rules can be used to encode any data object into a binary file. Read the object in octets.
+        CRLDistPoint distPoint;
+        try {
+            DEROctetString crlDEROctetString = (DEROctetString) asn1In.readObject();
+            //Get Input stream in octets
+            ASN1InputStream asn1InOctets = new ASN1InputStream(crlDEROctetString.getOctets());
+            ASN1Primitive crlDERObject = asn1InOctets.readObject();
+            distPoint = CRLDistPoint.getInstance(crlDERObject);
+        } catch (IOException e) {
+            throw new CertificateValidationException("Cannot read certificate to get CRL urls", e);
+        }
+
+        List<String> crlUrls = new ArrayList<String>();
+        //Loop through ASN1Encodable DistributionPoints
+        for (DistributionPoint dp : distPoint.getDistributionPoints()) {
+            //get ASN1Encodable DistributionPointName
+            DistributionPointName dpn = dp.getDistributionPoint();
+            if (dpn != null && dpn.getType() == DistributionPointName.FULL_NAME) {
+                //Create ASN1Encodable General Names
+                GeneralName[] genNames = GeneralNames.getInstance(dpn.getName()).getNames();
+                // Look for a URI
+                //todo: May be able to check for OCSP url specifically.
+                for (GeneralName genName : genNames) {
+                    if (genName.getTagNo() == GeneralName.uniformResourceIdentifier) {
+                        //DERIA5String contains an ascii string.
+                        //A IA5String is a restricted character string type in the ASN.1 notation
+                        String url = DERIA5String.getInstance(genName.getName()).getString().trim();
+                        crlUrls.add(url);
+                    }
+                }
+            }
+        }
+        if (crlUrls.isEmpty()) {
+            throw new CertificateValidationException("Cant get CRL urls from certificate");
+        }
+        return crlUrls;
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/validator/OCSPValidator.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/validator/OCSPValidator.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.validator;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers;
+import org.bouncycastle.asn1.ocsp.OCSPResponseStatus;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.ocsp.*;
+import org.bouncycastle.operator.DigestCalculatorProvider;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
+import org.wso2.carbon.identity.x509Certificate.validation.RevocationStatus;
+
+import java.io.*;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+/**
+ * This is used to verify a certificate is revoked or not by using the Online Certificate Status Protocol published
+ * by the CA.
+ */
+public class OCSPValidator implements RevocationValidator {
+
+    private static final Log log = LogFactory.getLog(OCSPValidator.class);
+    private int priority;
+    private boolean enabled;
+    private int retryCount;
+    private boolean fullChainValidationEnabled;
+    private static final String BC = "BC";
+
+    public OCSPValidator() {
+    }
+
+    @Override
+    public RevocationStatus checkRevocationStatus(X509Certificate peerCert, X509Certificate issuerCert, int retryCount)
+            throws CertificateValidationException {
+
+        if(issuerCert == null) {
+            throw new CertificateValidationException("Issuer Certificate is not available for OCSP validation");
+        }
+
+        OCSPReq request = generateOCSPRequest(issuerCert, peerCert.getSerialNumber());
+
+        //This list will sometimes have non ocsp urls as well.
+        List<String> locations = CertificateValidationUtil.getAIALocations(peerCert);
+
+        if(CollectionUtils.isNotEmpty(locations)) {
+            for (String serviceUrl : locations) {
+
+                SingleResp[] responses;
+                try {
+                    OCSPResp ocspResponse = getOCSPResponce(serviceUrl, request, retryCount);
+                    if (OCSPResponseStatus.SUCCESSFUL != ocspResponse.getStatus()) {
+                        continue; // Server didn't give the response right.
+                    }
+
+                    BasicOCSPResp basicResponse = (BasicOCSPResp) ocspResponse.getResponseObject();
+                    responses = (basicResponse == null) ? null : basicResponse.getResponses();
+                    //todo use the super exception
+                } catch (Exception e) {
+                    continue;
+                }
+
+                if (responses != null && responses.length == 1) {
+                    SingleResp resp = responses[0];
+                    RevocationStatus status = getRevocationStatus(resp);
+                    return status;
+                }
+            }
+        }
+        throw new CertificateValidationException("Cant get Revocation Status from OCSP.");
+    }
+
+    @Override
+    public boolean isEnable() {
+        return enabled;
+    }
+
+    @Override
+    public void setEnable(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+
+    @Override
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    @Override
+    public boolean isFullChainValidationEnable() {
+        return fullChainValidationEnabled;
+    }
+
+    @Override
+    public void setFullChainValidation(boolean fullChainValidationEnabled) {
+        this.fullChainValidationEnabled = fullChainValidationEnabled;
+    }
+
+    @Override
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+    @Override
+    public void setRetryCount(int retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    /**
+     * This method generates an OCSP Request to be sent to an OCSP endpoint.
+     *
+     * @param issuerCert   is the Certificate of the Issuer of the peer certificate we are interested in.
+     * @param serialNumber of the peer certificate.
+     * @return generated OCSP request.
+     * @throws CertificateValidationException
+     *
+     */
+    private static OCSPReq generateOCSPRequest(X509Certificate issuerCert, BigInteger serialNumber)
+            throws CertificateValidationException {
+
+        //TODO: Have to check if this is OK with synapse implementation.
+        //Add provider BC
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        try {
+
+            byte[] issuerCertEnc = issuerCert.getEncoded();
+            X509CertificateHolder certificateHolder = new X509CertificateHolder(issuerCertEnc);
+            DigestCalculatorProvider digCalcProv = new JcaDigestCalculatorProviderBuilder().setProvider(BC).build();
+
+            //  CertID structure is used to uniquely identify certificates that are the subject of
+            // an OCSP request or response and has an ASN.1 definition. CertID structure is defined in RFC 2560
+            CertificateID id = new CertificateID(digCalcProv.get(CertificateID.HASH_SHA1), certificateHolder, serialNumber);
+
+            // basic request generation with nonce
+            OCSPReqBuilder builder = new OCSPReqBuilder();
+            builder.addRequest(id);
+
+            // create details for nonce extension. The nonce extension is used to bind
+            // a request to a response to prevent replay attacks. As the name implies,
+            // the nonce value is something that the client should only use once within a reasonably small period.
+            BigInteger nonce = BigInteger.valueOf(System.currentTimeMillis());
+
+            //to create the request Extension
+            builder.setRequestExtensions(new Extensions(new Extension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce,false, new DEROctetString(nonce.toByteArray()))));
+
+            return builder.build();
+        } catch (Exception e) {
+            throw new CertificateValidationException("Cannot generate OSCP Request with the given certificate", e);
+        }
+    }
+
+    /**
+     * Gets an ASN.1 encoded OCSP response (as defined in RFC 2560) from the given service URL. Currently supports
+     * only HTTP.
+     *
+     * @param serviceUrl URL of the OCSP endpoint.
+     * @param request    an OCSP request object.
+     * @return OCSP response encoded in ASN.1 structure.
+     * @throws CertificateValidationException
+     *
+     */
+    private static OCSPResp getOCSPResponce(String serviceUrl, OCSPReq request, int retryCount)
+            throws CertificateValidationException {
+
+        OCSPResp ocspResp = null;
+        try {
+            //Todo: Use http client.
+            byte[] array = request.getEncoded();
+            if (serviceUrl.startsWith("http")) {
+                HttpURLConnection con;
+                URL url = new URL(serviceUrl);
+                con = (HttpURLConnection) url.openConnection();
+                con.setRequestProperty("Content-Type", "application/ocsp-request");
+                con.setRequestProperty("Accept", "application/ocsp-response");
+                con.setDoOutput(true);
+                OutputStream out = con.getOutputStream();
+                DataOutputStream dataOut = new DataOutputStream(new BufferedOutputStream(out));
+                dataOut.write(array);
+
+                dataOut.flush();
+                dataOut.close();
+
+                //Check errors in response:
+                if (con.getResponseCode() / 100 != 2) {
+                    throw new CertificateValidationException("Error getting ocsp response." +
+                            "Response code is " + con.getResponseCode());
+                }
+
+                //Get Response
+                InputStream in = (InputStream) con.getContent();
+                ocspResp = new OCSPResp(in);
+            } else {
+                throw new CertificateValidationException("Only http is supported for ocsp calls");
+            }
+        } catch (IOException e) {
+            if(retryCount == 0) {
+                throw new CertificateValidationException("Cannot get ocspResponse from url: " + serviceUrl, e);
+            } else {
+                log.info("Cant reach URI: " + serviceUrl + ". Retrying to connect - attempt " + retryCount);
+                getOCSPResponce(serviceUrl, request, --retryCount);
+            }
+        }
+        return ocspResp;
+    }
+
+    private static RevocationStatus getRevocationStatus(SingleResp resp) throws CertificateValidationException {
+        Object status = resp.getCertStatus();
+        if (status == CertificateStatus.GOOD) {
+            return RevocationStatus.GOOD;
+        } else if (status instanceof org.bouncycastle.cert.ocsp.RevokedStatus) {
+            return RevocationStatus.REVOKED;
+        } else if (status instanceof org.bouncycastle.cert.ocsp.UnknownStatus) {
+            return RevocationStatus.UNKNOWN;
+        }
+        throw new CertificateValidationException("Cant recognize Certificate Status");
+    }
+}

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/validator/RevocationValidator.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/validator/RevocationValidator.java
@@ -28,7 +28,7 @@ import java.security.cert.X509Certificate;
  */
 public interface RevocationValidator {
 
-    public RevocationStatus checkRevocationStatus(X509Certificate peerCert, X509Certificate issuerCert)
+    public RevocationStatus checkRevocationStatus(X509Certificate peerCert, X509Certificate issuerCert, int retryCount)
             throws CertificateValidationException;
 
     public boolean isEnable();
@@ -38,4 +38,12 @@ public interface RevocationValidator {
     public int getPriority();
 
     public void setPriority(int priority);
+
+    public boolean isFullChainValidationEnable();
+
+    public void setFullChainValidation(boolean fullChainValidationEnabled);
+
+    public int getRetryCount();
+
+    public void setRetryCount(int retryCount);
 }

--- a/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/validator/RevocationValidator.java
+++ b/component/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/validator/RevocationValidator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.validator;
+
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
+import org.wso2.carbon.identity.x509Certificate.validation.RevocationStatus;
+
+import java.security.cert.X509Certificate;
+
+/**
+ * All the revocation validators should implement this interface.
+ */
+public interface RevocationValidator {
+
+    public RevocationStatus checkRevocationStatus(X509Certificate peerCert, X509Certificate issuerCert)
+            throws CertificateValidationException;
+
+    public boolean isEnable();
+
+    public void setEnable(boolean enabled);
+
+    public int getPriority();
+
+    public void setPriority(int priority);
+}

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.feature</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
             <modules>
                 <module>component/authentication-endpoint</module>
                 <module>component/authenticator</module>
+                <module>component/validation</module>
                 <module>feature</module>
             </modules>
         </profile>
@@ -181,7 +182,23 @@
             <artifactId>encoder</artifactId>
             <version>${encoder.wso2.version}</version>
         </dependency>
-     </dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.registry.core</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+            <artifactId>org.wso2.carbon.extension.identity.x509Certificate.validation</artifactId>
+            <scope>provided</scope>
+            <version>${project.version}</version>
+        </dependency>
+        </dependencies>
     </dependencyManagement>
     <scm>
         <connection>scm:git:https://github.com/wso2-extensions/identity-outbound-auth-x509.git</connection>
@@ -365,8 +382,11 @@
     </distributionManagement>
     <properties>
         <carbon.identity.version>5.0.7</carbon.identity.version>
+        <carbon.identity.framework.version>5.7.5</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
+        </carbon.identity.framework.imp.pkg.version.range>
         <commons-logging.version>4.4.3</commons-logging.version>
-        <carbon.kernel.version>4.4.3</carbon.kernel.version>
+        <carbon.kernel.version>4.4.11</carbon.kernel.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
-    <version>2.0.4-SNAPSHOT</version>
+    <version>2.0.5-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - X509 Certificate POM</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
## Purpose
Include client certificate validation with CRL and OCSP in X509 authenticator

## Goals
- Improve X509 authenticator to extract CRL and OCSP URLs from the certificate (using “CRL Distribution Point” and “Authority Information Access” extensions respectively)
- Improve X509 authenticator to perform certificate revocation checks based on CRL (Certificate Revocation List) and OCSP (Online Certificate Status Protocol)
- Improve X509 authenticator to let administrator to override URLs of CRL and/or OCSP per certificate issuing authority, disable one or both method of certificate revocation check, or define preference between CRL and OCSP
- Improve X509 authenticator to cache CRLs, if CRL-based revocation check is taking place

## Approach

## Documentation

## Marketing

## Automation tests
 - Unit tests 
 - Integration tests