### PR TITLE
Certificate Revocation Validation with CRL and OCSP

### DIFF
--- a/component/authentication-endpoint/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/component/authentication-endpoint/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -21,3 +21,6 @@ userNotFoundInUserStore.error.message=Couldn't find X509 certificate's user in u
 unknown.error.code=51007
 certificate.not.found=X509 Certificate not found
 unknown.error.message=Something went wrong, please retry!
+not.valid.certificate=Provided Client X509 Certificate is not valid!
+fail.validation.certificate=Could not validate the provided client certificate!
+    }

--- a/component/authentication-endpoint/src/main/webapp/x509CertificateError.jsp
+++ b/component/authentication-endpoint/src/main/webapp/x509CertificateError.jsp
@@ -53,6 +53,10 @@
                     errorMessage = resourceBundle.getString("userNamesConflict.error.message");
                 } else if (errorCode.equalsIgnoreCase("17001")) {
                     errorMessage = resourceBundle.getString("userNotFoundInUserStore.error.message");
+                } else if (errorCode.equalsIgnoreCase("18015")) {
+                    errorMessage = resourceBundle.getString("not.valid.certificate");
+                } else if (errorCode.equalsIgnoreCase("17003")) {
+                    errorMessage = resourceBundle.getString("fail.validation.certificate");
                 }
             }
         }

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
+            <artifactId>org.wso2.carbon.extension.identity.x509Certificate.validation</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -188,16 +188,15 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
         boolean isSelfRegistrationEnable = Boolean.parseBoolean(getAuthenticatorConfig().getParameterMap().
                 get(X509CertificateConstants.ENFORCE_SELF_REGISTRATION));
         try {
-            isUserCertValid = X509CertificateUtil.validateCerts(userName, authenticationContext, data,
+            isUserCertValid = X509CertificateUtil.validateCertificate(userName, authenticationContext, data,
                     isSelfRegistrationEnable);
         } catch (AuthenticationFailedException e) {
             authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,
                     X509CertificateConstants.X509_CERTIFICATE_NOT_VALIDATED_ERROR_CODE);
-            throw new AuthenticationFailedException("Error in validating the user certificate");
+            throw new AuthenticationFailedException("Error in validating the user certificate", e);
         }
 
-
-        if(isUserCertValid) {
+        if (isUserCertValid) {
             allowUser(userName, claims, cert, authenticationContext);
         } else {
             authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
@@ -54,4 +54,7 @@ public class X509CertificateConstants {
     public static final String USERNAME_NOT_FOUND_FOR_X509_CERTIFICATE_ATTRIBUTE = "18003";
     public static final String X509_CERTIFICATE_USERNAME = "X509CertificateUsername";
     public static final String USER_NOT_FOUND = "17001";
+    public static final String X509_CERTIFICATE_NOT_VALID_ERROR_CODE = "18015";
+    public static final String X509_CERTIFICATE_NOT_VALIDATED_ERROR_CODE = "17003";
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -187,11 +187,6 @@
             <version>${carbon.kernel.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
-            <version>${carbon.identity.framework.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
             <artifactId>org.wso2.carbon.extension.identity.x509Certificate.validation</artifactId>
             <version>${identity.x509Certificate.validation.version}</version>
@@ -380,12 +375,9 @@
     </distributionManagement>
     <properties>
         <carbon.identity.version>5.0.7</carbon.identity.version>
-        <carbon.identity.framework.version>5.7.5</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
-        </carbon.identity.framework.imp.pkg.version.range>
-        <identity.x509Certificate.validation.version>1.0.0-SNAPSHOT</identity.x509Certificate.validation.version>
+        <identity.x509Certificate.validation.version>1.0.1</identity.x509Certificate.validation.version>
         <commons-logging.version>4.4.3</commons-logging.version>
-        <carbon.kernel.version>4.4.11</carbon.kernel.version>
+        <carbon.kernel.version>4.4.3</carbon.kernel.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,22 @@
             <artifactId>encoder</artifactId>
             <version>${encoder.wso2.version}</version>
         </dependency>
-     </dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.registry.core</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
+            <artifactId>org.wso2.carbon.extension.identity.x509Certificate.validation</artifactId>
+            <version>${identity.x509Certificate.validation.version}</version>
+        </dependency>
+        </dependencies>
     </dependencyManagement>
     <scm>
         <connection>scm:git:https://github.com/wso2-extensions/identity-outbound-auth-x509.git</connection>
@@ -365,8 +380,12 @@
     </distributionManagement>
     <properties>
         <carbon.identity.version>5.0.7</carbon.identity.version>
+        <carbon.identity.framework.version>5.7.5</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
+        </carbon.identity.framework.imp.pkg.version.range>
+        <identity.x509Certificate.validation.version>1.0.0-SNAPSHOT</identity.x509Certificate.validation.version>
         <commons-logging.version>4.4.3</commons-logging.version>
-        <carbon.kernel.version>4.4.3</carbon.kernel.version>
+        <carbon.kernel.version>4.4.11</carbon.kernel.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>


### PR DESCRIPTION
## Purpose
Including Certificate Revocation Validation with CRL and OCSP for X509 Authenticator

## Goals

## Approach

## User stories

## Release note

## Documentation

## Training

## Certification

## Marketing

## Automation tests

## Security checks

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
 
## Learning
