### PR TITLE
Exclude junit from packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,10 @@
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Purpose
> Currently junit-3.8.1.jar is packed in the webapp library which comes as a transitive dependency of org.wso2.securevault. 

## Goals
> Remove unnecessary dependencies from runtime.

## Approach
> Excluding the packaging of junit

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A
## Related PRs
> N/A

## Migrations (if applicable)
> N/A