### PR TITLE
Adding x509authentication valve for ssl termination

### DIFF
--- a/component/valves/pom.xml
+++ b/component/valves/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
+        <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+        <version>2.0.8</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.valve</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon Extension - X509 Certificate valve</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>${commons-lang.wso2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+            <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector</artifactId>
+            <version>2.0.8</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <commons-logging.version>4.4.3</commons-logging.version>
+    </properties>
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+    <build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-scr-plugin</artifactId>
+            <version>1.0.10</version>
+            <executions>
+                <execution>
+                    <id>generate-scr-scrdescriptor</id>
+                    <goals>
+                        <goal>scr</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <version>1.4.0</version>
+            <extensions>true</extensions>
+            <configuration>
+                <instructions>
+                    <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
+                    <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                    <Export-Package>
+                        org.wso2.carbon.identity.authenticator.x509cert.valve.*,
+                    </Export-Package>
+                        <Import-Package>
+                            javax.servlet; version=2.4.0,
+                            javax.servlet.http; version=2.4.0,
+                            org.apache.tomcat.*
+                            org.wso2.carbon.base.*,
+                            org.wso2.carbon.user.core.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18</version>
+            </plugin>
+            <plugin>
+                <inherited>false</inherited>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>2.1</version>
+            </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>8</source>
+                <target>8</target>
+            </configuration>
+        </plugin>
+    </plugins>
+    </build>
+</project>

--- a/component/valves/pom.xml
+++ b/component/valves/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>commons-lang.wso2</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.wso2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
@@ -47,13 +46,9 @@
         <dependency>
             <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
             <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector</artifactId>
-            <version>2.0.8</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
-    <properties>
-        <commons-logging.version>4.4.3</commons-logging.version>
-    </properties>
     <repositories>
         <repository>
             <id>wso2-nexus</id>
@@ -71,7 +66,6 @@
         <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-scr-plugin</artifactId>
-            <version>1.0.10</version>
             <executions>
                 <execution>
                     <id>generate-scr-scrdescriptor</id>
@@ -84,7 +78,6 @@
         <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
-            <version>1.4.0</version>
             <extensions>true</extensions>
             <configuration>
                 <instructions>
@@ -101,27 +94,20 @@
                             org.wso2.carbon.user.core.*,
                             *;resolution:=optional
                         </Import-Package>
-                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18</version>
             </plugin>
             <plugin>
                 <inherited>false</inherited>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.1</version>
             </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <source>8</source>
-                <target>8</target>
-            </configuration>
         </plugin>
     </plugins>
     </build>

--- a/component/valves/pom.xml
+++ b/component/valves/pom.xml
@@ -87,11 +87,8 @@
                         org.wso2.carbon.identity.authenticator.x509cert.valve.*,
                     </Export-Package>
                         <Import-Package>
-                            javax.servlet; version=2.4.0,
-                            javax.servlet.http; version=2.4.0,
-                            org.apache.tomcat.*
-                            org.wso2.carbon.base.*,
-                            org.wso2.carbon.user.core.*,
+                            javax.servlet; version="${imp.pkg.version.javax.servlet}",
+                            org.apache.tomcat.*; version="${imp.pkg.version.apache.tomcat}",
                             *;resolution:=optional
                         </Import-Package>
                     </instructions>
@@ -108,6 +105,12 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
+            <inherited>true</inherited>
+            <configuration>
+                <encoding>UTF-8</encoding>
+                <source>1.8</source>
+                <target>1.8</target>
+            </configuration>
         </plugin>
     </plugins>
     </build>

--- a/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/X509CertificateAuthenticationValve.java
+++ b/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/X509CertificateAuthenticationValve.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.authenticator.x509cert.valve;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ValveBase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.authenticator.x509Certificate.X509CertificateConstants;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Valve for extracting the X509Certificate passed as a request header through SSL termination and
+ * passing it as a request attribute.
+ */
+public class X509CertificateAuthenticationValve extends ValveBase {
+
+    private static final String X509_REQUEST_HEADER = "X-SSL-CERT";
+    private static final String X509CERT_NAME = "X509";
+    private static final String CERT_PEM_START = "[-]+BEGIN CERTIFICATE[-]+[\t]*[\n]*";
+    private static final String reg = "[-]+(BEGIN CERTIFICATE)[-]+[\t]*[\n]*([^-]+)[-]+(END CERTIFICATE)[-]+";
+    private static final String CERT_PEM_END = "[-]+END CERTIFICATE[-]+";
+
+    private static Log log = LogFactory.getLog(X509CertificateAuthenticationValve.class);
+
+    @Override
+    public void invoke(Request request, Response response) throws IOException, ServletException {
+            setX509certificate(request);
+            getNext().invoke(request, response);
+    }
+
+    /**
+     * Sets X509Certificate[] as an attribute in the request.
+     * @param request
+     */
+    private void setX509certificate(Request request){
+
+        X509Certificate certificate = getCertificate(request);
+        X509Certificate[] certificates = new X509Certificate[]{certificate};
+        request.setAttribute(X509CertificateConstants.X_509_CERTIFICATE, certificates);
+        if(log.isDebugEnabled()){
+            log.debug("X509certificate is set as an attribute in the request");
+        }
+    }
+
+    /**
+     * Returns the X509Certificate extracted from the request header.
+     * @param request
+     * @return X509Certificate
+     */
+    private X509Certificate getCertificate(Request request) {
+
+        String ssl_cert = request.getHeader(X509_REQUEST_HEADER);
+        X509Certificate certificate = null;
+        if (ssl_cert != null && ! ssl_cert.trim().isEmpty()) {
+            Pattern pattern = Pattern.compile(reg);
+            Matcher matcher = pattern.matcher(ssl_cert);
+            if (matcher.matches()){
+                String replaced_ssl_cert = ssl_cert.replaceAll(CERT_PEM_START, "")
+                        .replaceAll(CERT_PEM_END, ""); // Need for the pem format
+                byte[] certificateData = Base64.getMimeDecoder().decode(replaced_ssl_cert);
+                CertificateFactory cf = null;
+                try {
+                    cf = CertificateFactory.getInstance(X509CERT_NAME);
+                    certificate = (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(certificateData));
+                } catch (CertificateException e) {
+                    log.error("Error occurred in generating certificate: " + request.getRequestURI(), e);
+                }
+            }
+        }
+        return certificate;
+    }
+}

--- a/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/X509CertificateAuthenticationValve.java
+++ b/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/X509CertificateAuthenticationValve.java
@@ -26,16 +26,17 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.authenticator.x509Certificate.X509CertificateConstants;
+import org.wso2.carbon.identity.authenticator.x509cert.valve.config.X509ServerConfiguration;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import javax.servlet.ServletException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.servlet.ServletException;
 
 /**
  * Valve for extracting the X509Certificate passed as a request header through SSL termination and
@@ -43,11 +44,11 @@ import java.util.regex.Pattern;
  */
 public class X509CertificateAuthenticationValve extends ValveBase {
 
-    private static final String X509_REQUEST_HEADER = "X-SSL-CERT";
     private static final String X509CERT_NAME = "X509";
     private static final String CERT_PEM_START = "[-]+(BEGIN CERTIFICATE)[-]+[\t]*[\n]*";
     private static final String CERT_PEM_END = "[-]+(END CERTIFICATE)[-]+";
     private static final Pattern PATTERN = Pattern.compile(CERT_PEM_START + "([^-]+)" + CERT_PEM_END);
+    private X509ServerConfiguration config = null;
 
     private static Log log = LogFactory.getLog(X509CertificateAuthenticationValve.class);
 
@@ -85,7 +86,7 @@ public class X509CertificateAuthenticationValve extends ValveBase {
     private X509Certificate getCertificate(Request request) {
 
         X509Certificate certificate = null;
-        String pemCert = request.getHeader(X509_REQUEST_HEADER);
+        String pemCert = request.getHeader(getX509HeaderName());
         if (StringUtils.isNotEmpty(pemCert)) {
             Matcher matcher = PATTERN.matcher(pemCert);
             if (matcher.matches()) {
@@ -101,5 +102,12 @@ public class X509CertificateAuthenticationValve extends ValveBase {
             }
         }
         return certificate;
+    }
+
+    private String getX509HeaderName() {
+
+        config = X509ServerConfiguration.getInstance();
+        String x509HeaderName = config.getX509requestHeader();
+        return x509HeaderName;
     }
 }

--- a/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/X509CertificateAuthenticationValve.java
+++ b/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/X509CertificateAuthenticationValve.java
@@ -19,6 +19,7 @@
 
 package org.wso2.carbon.identity.authenticator.x509cert.valve;
 
+import org.apache.axiom.om.util.Base64;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
@@ -33,7 +34,6 @@ import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.servlet.ServletException;
@@ -91,8 +91,8 @@ public class X509CertificateAuthenticationValve extends ValveBase {
             Matcher matcher = PATTERN.matcher(pemCert);
             if (matcher.matches()) {
                 String pemCertBody = pemCert.replaceAll(CERT_PEM_START, "").replaceAll(CERT_PEM_END, "");
-                byte[] certificateData = Base64.getMimeDecoder().decode(pemCertBody);
 
+                byte[] certificateData = Base64.decode(pemCertBody);
                 try {
                     CertificateFactory cf = CertificateFactory.getInstance(X509CERT_NAME);
                     certificate = (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(certificateData));

--- a/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/X509CertificateAuthenticationValve.java
+++ b/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/X509CertificateAuthenticationValve.java
@@ -86,7 +86,7 @@ public class X509CertificateAuthenticationValve extends ValveBase {
     private X509Certificate getCertificate(Request request) {
 
         X509Certificate certificate = null;
-        String pemCert = request.getHeader(getX509HeaderName());
+        String pemCert = request.getHeader(getX509RequestHeaderName());
         if (StringUtils.isNotEmpty(pemCert)) {
             Matcher matcher = PATTERN.matcher(pemCert);
             if (matcher.matches()) {
@@ -104,7 +104,11 @@ public class X509CertificateAuthenticationValve extends ValveBase {
         return certificate;
     }
 
-    private String getX509HeaderName() {
+    /**
+     *  Get the name of X509Certificate request header.
+     * @return header name
+     */
+    private String getX509RequestHeaderName() {
 
         config = X509ServerConfiguration.getInstance();
         String x509HeaderName = config.getX509requestHeader();

--- a/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/config/X509ServerConfiguration.java
+++ b/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/config/X509ServerConfiguration.java
@@ -1,0 +1,85 @@
+package org.wso2.carbon.identity.authenticator.x509cert.valve.config;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import javax.xml.namespace.QName;
+
+public class X509ServerConfiguration {
+
+    private static Log log = LogFactory.getLog(X509ServerConfiguration.class);
+    private static X509ServerConfiguration instance;
+    private static final String CONFIG_ELEM_X509 = "X509";
+
+    private String x509requestHeader = "X-SSL-CERT";
+
+    private X509ServerConfiguration() {
+
+        buildOAuthServerConfiguration();
+    }
+
+    public static X509ServerConfiguration getInstance() {
+
+        CarbonUtils.checkSecurity();
+        if (instance == null) {
+            synchronized (X509ServerConfiguration.class) {
+                if (instance == null) {
+                    instance = new X509ServerConfiguration();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * @return name of the X509 request header
+     */
+    public String getX509requestHeader() {
+
+        return x509requestHeader;
+    }
+
+    private void buildOAuthServerConfiguration() {
+
+        IdentityConfigParser configParser = IdentityConfigParser.getInstance();
+        OMElement x509Elem = configParser.getConfigElement(CONFIG_ELEM_X509);
+
+        if (x509Elem == null) {
+            warnOnFaultyConfiguration("X509 element is not available.");
+            return;
+        }
+
+        // Read X509 Configurations.
+        parseX509ServerValidators(x509Elem);
+    }
+
+    private void parseX509ServerValidators(OMElement x509Elem) {
+
+        // Get the configured name of the X509Request header.
+        if (x509Elem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.X509_REQUEST_HEADER)) != null) {
+            x509requestHeader =
+                    x509Elem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.X509_REQUEST_HEADER))
+                            .getText().trim();
+        }
+    }
+
+    private void warnOnFaultyConfiguration(String logMsg) {
+
+        log.warn("Error in X509 Configuration. " + logMsg);
+    }
+
+    private QName getQNameWithIdentityNS(String localPart) {
+
+        return new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, localPart);
+    }
+
+    private class ConfigElements {
+
+        // X509 Request header
+        public static final String X509_REQUEST_HEADER = "X509RequestHeaderName";
+    }
+}

--- a/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/config/X509ServerConfiguration.java
+++ b/component/valves/src/main/java/org/wso2/carbon/identity/authenticator/x509cert/valve/config/X509ServerConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
 package org.wso2.carbon.identity.authenticator.x509cert.valve.config;
 
 import org.apache.axiom.om.OMElement;
@@ -14,12 +32,13 @@ public class X509ServerConfiguration {
     private static Log log = LogFactory.getLog(X509ServerConfiguration.class);
     private static X509ServerConfiguration instance;
     private static final String CONFIG_ELEM_X509 = "X509";
+    private static final String CONFIG_ELEM_X509_REQUEST_HEADER = "X509RequestHeaderName";
 
     private String x509requestHeader = "X-SSL-CERT";
 
     private X509ServerConfiguration() {
 
-        buildOAuthServerConfiguration();
+        buildX509ServerConfiguration();
     }
 
     public static X509ServerConfiguration getInstance() {
@@ -43,33 +62,29 @@ public class X509ServerConfiguration {
         return x509requestHeader;
     }
 
-    private void buildOAuthServerConfiguration() {
+    private void buildX509ServerConfiguration() {
 
         IdentityConfigParser configParser = IdentityConfigParser.getInstance();
         OMElement x509Elem = configParser.getConfigElement(CONFIG_ELEM_X509);
 
         if (x509Elem == null) {
-            warnOnFaultyConfiguration("X509 element is not available.");
+            log.debug("X509 Request header configuration is not enabled");
             return;
         }
 
         // Read X509 Configurations.
-        parseX509ServerValidators(x509Elem);
+        parseX509ServerConfigurations(x509Elem);
     }
 
-    private void parseX509ServerValidators(OMElement x509Elem) {
+    private void parseX509ServerConfigurations(OMElement x509Elem) {
 
         // Get the configured name of the X509Request header.
-        if (x509Elem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.X509_REQUEST_HEADER)) != null) {
-            x509requestHeader =
-                    x509Elem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.X509_REQUEST_HEADER))
-                            .getText().trim();
+        String requestHeaderName =
+                x509Elem.getFirstChildWithName(getQNameWithIdentityNS(CONFIG_ELEM_X509_REQUEST_HEADER))
+                        .getText().trim();
+        if (requestHeaderName != null) {
+            x509requestHeader = requestHeaderName;
         }
-    }
-
-    private void warnOnFaultyConfiguration(String logMsg) {
-
-        log.warn("Error in X509 Configuration. " + logMsg);
     }
 
     private QName getQNameWithIdentityNS(String localPart) {
@@ -77,9 +92,4 @@ public class X509ServerConfiguration {
         return new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, localPart);
     }
 
-    private class ConfigElements {
-
-        // X509 Request header
-        public static final String X509_REQUEST_HEADER = "X509RequestHeaderName";
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
             <modules>
                 <module>component/authentication-endpoint</module>
                 <module>component/authenticator</module>
+                <module>component/valves</module>
                 <module>feature</module>
             </modules>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -402,5 +402,7 @@
         <org.apache.oltu.oauth2.client>0.31</org.apache.oltu.oauth2.client>
         <org.apache.oltu.oauth2.common>1.0.1</org.apache.oltu.oauth2.common>
         <authenticator.x509Certificate.connector>2.0.8</authenticator.x509Certificate.connector>
+        <imp.pkg.version.javax.servlet>2.4.0</imp.pkg.version.javax.servlet>
+        <imp.pkg.version.apache.tomcat>[7.0.0, 9.0.0)</imp.pkg.version.apache.tomcat>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,12 @@
             <artifactId>org.wso2.carbon.extension.identity.x509Certificate.validation</artifactId>
             <version>${identity.x509Certificate.validation.version}</version>
         </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+                <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector</artifactId>
+                <version>${authenticator.x509Certificate.connector}</version>
+                <scope>compile</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <scm>
@@ -395,5 +401,6 @@
         <maven.compiler.war.version>2.2</maven.compiler.war.version>
         <org.apache.oltu.oauth2.client>0.31</org.apache.oltu.oauth2.client>
         <org.apache.oltu.oauth2.common>1.0.1</org.apache.oltu.oauth2.common>
+        <authenticator.x509Certificate.connector>2.0.8</authenticator.x509Certificate.connector>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
> X509 Certificate based authentication fails when SSL termination happens at load balancer.

## Goals
> When Load balancer sends X509 Certificate in the header, this valve can extract the certificate from the request header and pass that as a request attribute. So IS can authenticate the client using the certificate. So X509 Certificate based Authentication will succeed even when SSL termination happens at load balancer.

## Approach
> N/A
## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
>N/A

## Test environment
>N/A
 
## Learning
> N/A