### PR TITLE
Resolve X509 Certificate based authentication failure in the tenant mode

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -324,7 +324,7 @@ public class X509CertificateUtil {
             throws UserStoreException, AuthenticationFailedException {
 
         boolean isUserExist = X509CertificateUtil.getUserRealm(userName).getUserStoreManager().isExistingUser
-                (userName);
+                (MultitenantUtils.getTenantAwareUsername(userName));
         if (isUserExist) {
             if (log.isDebugEnabled()) {
                 log.debug("User exists with the user name: " + userName);


### PR DESCRIPTION
## Purpose
> Fixed wso2/product-is#4745

## Approach
> X509CertificateAuthenticator checks whether the user is existing in the relevant tenant domain and user store. After it identifies the user tenant domain and user store the tenant domain removed user name should be given to finding the user is existing or not. Therefore used the 
MultitenantUtils.getTenantAwareUsername to remove the tenant domain
