### PR TITLE
Adding userstore search option if X509 users are in a secondary userstore

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
@@ -68,7 +69,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
     private Pattern subjectPatternCompiled;
     private String subjectAttributePattern;
     private String alternativeNamePattern;
-    private String X509UserStoreName;
+    private String x509UserStoreName;
 
     private static final Log log = LogFactory.getLog(X509CertificateAuthenticator.class);
 
@@ -78,7 +79,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                 .get(X509CertificateConstants.USER_NAME_REGEX);
         alternativeNamePattern = getAuthenticatorConfig().getParameterMap()
                 .get(X509CertificateConstants.AlTN_NAMES_REGEX);
-        X509UserStoreName = getAuthenticatorConfig().getParameterMap()
+        x509UserStoreName = getAuthenticatorConfig().getParameterMap()
                 .get(X509CertificateConstants.X509_USER_STORE_NAME);
         if (alternativeNamePattern != null) {
             alternativeNamesPatternCompiled = Pattern.compile(alternativeNamePattern);
@@ -165,8 +166,8 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                 String subjectAttribute;
                 if (alternativeNamePattern != null) {
                      alternativeName = getMatchedAlternativeName(cert, authenticationContext);
-                     if (X509UserStoreName != null) {
-                         alternativeName = X509UserStoreName + "/" + alternativeName;
+                     if (x509UserStoreName != null) {
+                         alternativeName = UserCoreUtil.addDomainToName(alternativeName, x509UserStoreName);
                      }
                      validateUsingSubject(alternativeName, authenticationContext, cert, claims);
                      if(log.isDebugEnabled()){
@@ -175,8 +176,8 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                     authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_USERNAME, alternativeName);
                 } else if (subjectAttributePattern != null){
                     subjectAttribute = getMatchedSubjectAttribute(certAttributes, authenticationContext);
-                    if (X509UserStoreName != null) {
-                        subjectAttribute = X509UserStoreName + "/" + subjectAttribute;
+                    if (x509UserStoreName != null) {
+                        subjectAttribute = UserCoreUtil.addDomainToName(subjectAttribute, x509UserStoreName);
                     }
                     validateUsingSubject(subjectAttribute, authenticationContext, cert, claims);
                     if(log.isDebugEnabled()){

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
@@ -67,5 +67,6 @@ public class X509CertificateConstants {
             + "names in the certificate";
     public static final String X509_CERTIFICATE_SUBJECTDN_REGEX_NO_MATCHES_ERROR = "Regex configured but no matching "
             + "subjectRDN found for the given regex";
+    public static final String X509_USER_STORE_NAME = "X509UserStoreName";
 
 }


### PR DESCRIPTION
## Purpose
The current implementation checks for the user specified in the CN or Subject Alternative Name in the primary user store, if the user is in a secondary store the user will have to be defined in the following format in the certificate: USER-STORE-NAME/USER-NAME. With this change the secondary user store to search the user can be defined in the application-authentication.xml as follows with an "X509UserStoreName" parameter:

        <AuthenticatorConfig name="x509CertificateAuthenticator" enabled="true">
            <Parameter name="AuthenticationEndpoint">https://localhost:443/x509-certificate-servlet</Parameter>
            <!-- <Parameter name="username">CN</Parameter> -->
            <!-- <Parameter name="UsernameRegex">[a-zA-Z]{3}</Parameter> -->
            <Parameter name="AlternativeNamesRegex">[a-zA-Z]{7}</Parameter>
            <Parameter name="X509UserStoreName">SECONDARY</Parameter>
            <!--<Parameter name="setClaimURI">http://wso2.org/claims/identity/userCertificate</Parameter>-->
            <!--<Parameter name="EnforceSelfRegistration">true</Parameter>-->
        </AuthenticatorConfig>