### PR TITLE
Update parent groupId and change to next development version in master branch

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -17,9 +17,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+        <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.x509Certificate</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
-        <version>2.0.15-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector</artifactId>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -19,9 +19,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+        <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.x509Certificate</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
-        <version>2.0.15-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.feature</artifactId>
@@ -31,7 +31,7 @@
     <description>This feature contains extension feature for X509Certificate</description>
     <dependencies>
         <dependency>
-            <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+            <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.x509Certificate</groupId>
             <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -61,7 +61,7 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>
-                                    org.wso2.carbon.extension.identity.authenticator:org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector
+                                    org.wso2.carbon.extension.identity.authenticator.outbound.x509Certificate:org.wso2.carbon.extension.identity.authenticator.x509Certificate.connector
                                 </bundleDef>
                             </bundles>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
         <artifactId>wso2</artifactId>
         <version>1</version>
     </parent>
-    <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+    <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.x509Certificate</groupId>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.x509Certificate</artifactId>
-    <version>2.0.15-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - X509 Certificate POM</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
## Purpose
> Update the groupId of the parent in order to align with current naming convention used in outbound provisioning connectors and do a major release of the connector.