### PR TITLE
Changing the isAccountLocked method by adding username and tenant domain

### DIFF
--- a/component/authentication-endpoint/pom.xml
+++ b/component/authentication-endpoint/pom.xml
@@ -37,6 +37,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.taglibs</groupId>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -532,7 +532,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
             if (log.isDebugEnabled()) {
                 log.debug("Authenticated username is: " + authenticatedUser);
             }
-            String authenticatedUserName = authenticatedUser.getAuthenticatedSubjectIdentifier();
+            String authenticatedUserName = getAuthenticUserName(authenticatedUser.getAuthenticatedSubjectIdentifier());
             if (authenticatedUserName.equals(subject)) {
                 addOrValidateCertificate(subject, authenticationContext, data, claims, cert);
             } else {
@@ -544,6 +544,20 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
         } else {
             addOrValidateCertificate(subject, authenticationContext, data, claims, cert);
         }
+    }
+    /**
+     * check and validate the tenant domain of the user.
+     *
+     * @param userName               user name of the authenticated user.
+     */
+    private String getAuthenticUserName(String userName){
+        String authenticUser = null;
+        String tempUser = null;
+        if (userName.contains("carbon.super")) {
+            tempUser = userName.substring(userName.lastIndexOf('@') );
+            authenticUser = userName.replace(tempUser, "");
+            return authenticUser;
+        }else return userName;
     }
 
     private void addMatchStringsToList(Matcher matcher, Set<String> matches) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -532,7 +532,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
             if (log.isDebugEnabled()) {
                 log.debug("Authenticated username is: " + authenticatedUser);
             }
-            String authenticatedUserName = getAuthenticUserName(authenticatedUser.getAuthenticatedSubjectIdentifier());
+            String authenticatedUserName = getAuthenticatedUserName(authenticatedUser.getAuthenticatedSubjectIdentifier());
             if (authenticatedUserName.equals(subject)) {
                 addOrValidateCertificate(subject, authenticationContext, data, claims, cert);
             } else {
@@ -548,9 +548,9 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
     /**
      * check and validate the tenant domain of the user.
      *
-     * @param userName               user name of the authenticated user.
+     * @param userName          Check the user's tenant domain and build the user name according to that.
      */
-    private String getAuthenticUserName(String userName){
+    private String getAuthenticatedUserName(String userName){
 
         String authenticUser = null;
         String tempUser = null;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -548,9 +548,9 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
     }
 
     /**
-     * check and validate the tenant domain of the user.
+     * Check the authenticated user's tenant domain and verify whether it from super tenant or different tenant.
      *
-     * @param authenticatedUser Check the authenticated user's tenant domain and verify whether it from super tenant or different tenant .
+     * @param authenticatedUser Get the authenticated user object from the authentication context  .
      */
     private String getAuthenticatedUserName(AuthenticatedUser authenticatedUser) {
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -286,7 +286,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
 
         try {
             // Check whether user account is locked or not.
-            if (isAccountLock(getUsername(authenticationContext))) {
+            if (isAccountLock(userName, authenticationContext.getTenantDomain())) {
                 authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,
                         X509CertificateConstants.USER_ACCOUNT_LOCKED);
                 throw new AuthenticationFailedException("Account is locked for user: " + userName);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.IOException;
 import java.security.cert.CertificateEncodingException;
@@ -554,11 +555,11 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
      */
     private String getAuthenticatedUserName(AuthenticatedUser authenticatedUser) {
 
-        String carbonSuperUser = null;
-        if (authenticatedUser.getAuthenticatedSubjectIdentifier().contains("carbon.super")) {
-            carbonSuperUser = authenticatedUser.getUserName();
-            return carbonSuperUser;
-        } else return authenticatedUser.getAuthenticatedSubjectIdentifier();
+        String userName = authenticatedUser.getAuthenticatedSubjectIdentifier();
+        if (userName.endsWith(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            userName = authenticatedUser.getUserName();
+        }
+        return userName;
     }
 
     private void addMatchStringsToList(Matcher matcher, Set<String> matches) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -551,13 +551,15 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
      * @param userName               user name of the authenticated user.
      */
     private String getAuthenticUserName(String userName){
+
         String authenticUser = null;
         String tempUser = null;
         if (userName.contains("carbon.super")) {
             tempUser = userName.substring(userName.lastIndexOf('@') );
             authenticUser = userName.replace(tempUser, "");
             return authenticUser;
-        }else return userName;
+        } else return userName;
+
     }
 
     private void addMatchStringsToList(Matcher matcher, Set<String> matches) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -382,20 +382,21 @@ public class X509CertificateUtil {
     /**
      * Check whether user account is locked or not.
      *
-     * @param user Authenticated user.
+     * @param user  user that passed from the cert CN value.
+     *  @param tenantDomain  from "authenticationcontex".
      * @return boolean account locked or not.
      * @throws AccountLockServiceException
      */
-    public static boolean isAccountLock(AuthenticatedUser user) throws AccountLockServiceException {
+    public static boolean isAccountLock(String user, String tenantDomain) throws AccountLockServiceException {
 
         boolean accountLock = false;
         if (user != null) {
             try {
                 accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(user
-                        .getUserName(), user.getTenantDomain());
+                        , tenantDomain);
             } catch (AccountLockServiceException e) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Error while calling the account lock service for user " + user.getUserName(), e);
+                    log.debug("Error while calling the account lock service for user " + user, e);
                 }
                 throw e;
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -383,7 +383,7 @@ public class X509CertificateUtil {
      * Check whether user account is locked or not.
      *
      * @param userName  user that passed from the cert CN value.
-     *  @param tenantDomain  from "authenticationcontex".
+     *  @param tenantDomain  from "authenticationcontext".
      * @return boolean account locked or not.
      * @throws AccountLockServiceException
      */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -55,6 +55,7 @@ import java.util.Map;
  * Working with certificate and claims store.
  */
 public class X509CertificateUtil {
+
     private static final Log log = LogFactory.getLog(X509CertificateUtil.class);
 
     /**
@@ -65,6 +66,7 @@ public class X509CertificateUtil {
      * @throws AuthenticationFailedException authentication failed exception
      */
     public static X509Certificate getCertificate(String username) throws AuthenticationFailedException {
+
         X509Certificate x509Certificate;
         UserRealm userRealm = getUserRealm(username);
         try {
@@ -109,6 +111,7 @@ public class X509CertificateUtil {
      */
     public static boolean addCertificate(String username, X509Certificate x509Certificate)
             throws AuthenticationFailedException {
+
         Map<String, String> claims = new HashMap<>();
         UserRealm userRealm = getUserRealm(username);
         try {
@@ -146,6 +149,7 @@ public class X509CertificateUtil {
     public static boolean validateCertificate(String userName, AuthenticationContext authenticationContext,
                                               byte[] certificateBytes, boolean isSelfRegistrationEnable)
             throws AuthenticationFailedException {
+
         X509Certificate x509Certificate;
         try {
             CertificateFactory cf = CertificateFactory.getInstance("X509");
@@ -187,6 +191,7 @@ public class X509CertificateUtil {
      * @return boolean status of availability
      */
     public static boolean isCertificateExist(String userName) throws AuthenticationFailedException {
+
         return getCertificate(userName) != null;
     }
 
@@ -194,6 +199,7 @@ public class X509CertificateUtil {
      * Get parameter values from local file.
      */
     public static Map<String, String> getX509Parameters() {
+
         AuthenticatorConfig authConfig = FileBasedConfigurationBuilder.getInstance()
                 .getAuthenticatorBean(X509CertificateConstants.AUTHENTICATOR_NAME);
         if (authConfig != null) {
@@ -211,6 +217,7 @@ public class X509CertificateUtil {
      * @return X509Certificate claimURI
      */
     public static String getClaimUri() {
+
         String claimURI = X509CertificateConstants.CLAIM_DIALECT_URI;
         Map<String, String> parametersMap = getX509Parameters();
         if (parametersMap != null) {
@@ -233,6 +240,7 @@ public class X509CertificateUtil {
      * @throws AuthenticationFailedException
      */
     public static UserRealm getUserRealm(String username) throws AuthenticationFailedException {
+
         UserRealm userRealm = null;
         if (log.isDebugEnabled()) {
             log.debug("Getting userRealm for user: " + username);
@@ -331,7 +339,8 @@ public class X509CertificateUtil {
 
         if (Boolean.valueOf(getX509Parameters().get(X509CertificateConstants.SEARCH_ALL_USERSTORES))) {
             String[] filteredUsers = X509CertificateUtil.getUserRealm(userName).getUserStoreManager().listUsers
-                    (MultitenantUtils.getTenantAwareUsername(userName), X509CertificateConstants.MAX_ITEM_LIMIT_UNLIMITED);
+                    (MultitenantUtils.getTenantAwareUsername(userName),
+                            X509CertificateConstants.MAX_ITEM_LIMIT_UNLIMITED);
             if (filteredUsers.length == 1) {
                 if (log.isDebugEnabled()) {
                     log.debug("User exists with the user name: " + userName);
@@ -380,15 +389,15 @@ public class X509CertificateUtil {
     }
 
     /**
-     * Check whether user account is locked or not.
+     * Get the user account state by checking whether user account is locked or not.
      *
      * @param subject userName that passed from the cert CN value.
      * @return boolean account locked or not.
      * @throws AccountLockServiceException
      */
-    public static boolean isAccountLock(String subject) throws AccountLockServiceException {
+    public static boolean getAccountState(String subject) throws AccountLockServiceException {
         //Get the tenantaware username & particular tenant domain
-        String userName = null;
+        String userName = subject;
         String tenantDomain = null;
         if (subject.contains("@")) {
             userName = subject.substring(0, subject.lastIndexOf('@'));

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -388,15 +388,20 @@ public class X509CertificateUtil {
      * @throws AccountLockServiceException
      */
     public static boolean isAccountLock(String userName, String tenantDomain) throws AccountLockServiceException {
-
+        //Get the tenantaware username
+        String user = null;
+        if (userName.contains("@")) {
+            tenantDomain = userName.substring(userName.lastIndexOf('@') );
+            user = userName.replace(tenantDomain, "");
+        }
         boolean accountLock = false;
         if (userName != null) {
             try {
-                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(userName
+                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(user
                         , tenantDomain);
             } catch (AccountLockServiceException e) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Error while calling the account lock service for user " + userName, e);
+                    log.debug("Error while calling the account lock service for user " + user, e);
                 }
                 throw e;
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -55,7 +55,6 @@ import java.util.Map;
  * Working with certificate and claims store.
  */
 public class X509CertificateUtil {
-
     private static final Log log = LogFactory.getLog(X509CertificateUtil.class);
 
     /**
@@ -66,7 +65,6 @@ public class X509CertificateUtil {
      * @throws AuthenticationFailedException authentication failed exception
      */
     public static X509Certificate getCertificate(String username) throws AuthenticationFailedException {
-
         X509Certificate x509Certificate;
         UserRealm userRealm = getUserRealm(username);
         try {
@@ -111,7 +109,6 @@ public class X509CertificateUtil {
      */
     public static boolean addCertificate(String username, X509Certificate x509Certificate)
             throws AuthenticationFailedException {
-
         Map<String, String> claims = new HashMap<>();
         UserRealm userRealm = getUserRealm(username);
         try {
@@ -149,7 +146,6 @@ public class X509CertificateUtil {
     public static boolean validateCertificate(String userName, AuthenticationContext authenticationContext,
                                               byte[] certificateBytes, boolean isSelfRegistrationEnable)
             throws AuthenticationFailedException {
-
         X509Certificate x509Certificate;
         try {
             CertificateFactory cf = CertificateFactory.getInstance("X509");
@@ -191,7 +187,6 @@ public class X509CertificateUtil {
      * @return boolean status of availability
      */
     public static boolean isCertificateExist(String userName) throws AuthenticationFailedException {
-
         return getCertificate(userName) != null;
     }
 
@@ -199,7 +194,6 @@ public class X509CertificateUtil {
      * Get parameter values from local file.
      */
     public static Map<String, String> getX509Parameters() {
-
         AuthenticatorConfig authConfig = FileBasedConfigurationBuilder.getInstance()
                 .getAuthenticatorBean(X509CertificateConstants.AUTHENTICATOR_NAME);
         if (authConfig != null) {
@@ -217,7 +211,6 @@ public class X509CertificateUtil {
      * @return X509Certificate claimURI
      */
     public static String getClaimUri() {
-
         String claimURI = X509CertificateConstants.CLAIM_DIALECT_URI;
         Map<String, String> parametersMap = getX509Parameters();
         if (parametersMap != null) {
@@ -240,7 +233,6 @@ public class X509CertificateUtil {
      * @throws AuthenticationFailedException
      */
     public static UserRealm getUserRealm(String username) throws AuthenticationFailedException {
-
         UserRealm userRealm = null;
         if (log.isDebugEnabled()) {
             log.debug("Getting userRealm for user: " + username);
@@ -339,8 +331,7 @@ public class X509CertificateUtil {
 
         if (Boolean.valueOf(getX509Parameters().get(X509CertificateConstants.SEARCH_ALL_USERSTORES))) {
             String[] filteredUsers = X509CertificateUtil.getUserRealm(userName).getUserStoreManager().listUsers
-                    (MultitenantUtils.getTenantAwareUsername(userName),
-                            X509CertificateConstants.MAX_ITEM_LIMIT_UNLIMITED);
+                    (MultitenantUtils.getTenantAwareUsername(userName), X509CertificateConstants.MAX_ITEM_LIMIT_UNLIMITED);
             if (filteredUsers.length == 1) {
                 if (log.isDebugEnabled()) {
                     log.debug("User exists with the user name: " + userName);
@@ -389,15 +380,15 @@ public class X509CertificateUtil {
     }
 
     /**
-     * Get the user account state by checking whether user account is locked or not.
+     * Check whether user account is locked or not.
      *
      * @param subject userName that passed from the cert CN value.
      * @return boolean account locked or not.
      * @throws AccountLockServiceException
      */
-    public static boolean getAccountState(String subject) throws AccountLockServiceException {
+    public static boolean isAccountLock(String subject) throws AccountLockServiceException {
         //Get the tenantaware username & particular tenant domain
-        String userName = subject;
+        String userName = null;
         String tenantDomain = null;
         if (subject.contains("@")) {
             userName = subject.substring(0, subject.lastIndexOf('@'));

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -380,7 +380,7 @@ public class X509CertificateUtil {
     }
 
     /**
-     * Check whether user account is locked or not.
+     * Get the user account state by checking  whether the user account is locked or not.
      *
      * @param subject userName that passed from the cert CN value.
      * @return boolean account locked or not.
@@ -388,7 +388,38 @@ public class X509CertificateUtil {
      */
     public static boolean isAccountLock(String subject) throws AccountLockServiceException {
         //Get the tenantaware username & particular tenant domain
-        String userName = null;
+        String userName = subject;
+        String tenantDomain = null;
+        if (subject.contains("@")) {
+            userName = subject.substring(0, subject.lastIndexOf('@'));
+            tenantDomain = subject.substring(subject.lastIndexOf('@') + 1);
+        }
+
+        boolean accountLock = false;
+        if (userName != null) {
+            try {
+                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(userName
+                        , tenantDomain);
+            } catch (AccountLockServiceException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error while calling the account lock service for user " + userName, e);
+                }
+                throw e;
+            }
+        }
+        return accountLock;
+    }
+
+    /**
+     * Check whether user account is locked or not.
+     *
+     * @param subject userName that passed from the cert CN value.
+     * @return boolean account locked or not.
+     * @throws AccountLockServiceException
+     */
+    public static boolean isAccountLocked(String subject) throws AccountLockServiceException {
+        //Get the tenantaware username & particular tenant domain
+        String userName = subject;
         String tenantDomain = null;
         if (subject.contains("@")) {
             userName = subject.substring(0, subject.lastIndexOf('@'));

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -411,37 +411,6 @@ public class X509CertificateUtil {
     }
 
     /**
-     * Check whether user account is locked or not.
-     *
-     * @param subject userName that passed from the cert CN value.
-     * @return boolean account locked or not.
-     * @throws AccountLockServiceException
-     */
-    public static boolean isAccountLocked(String subject) throws AccountLockServiceException {
-        //Get the tenantaware username & particular tenant domain
-        String userName = subject;
-        String tenantDomain = null;
-        if (subject.contains("@")) {
-            userName = subject.substring(0, subject.lastIndexOf('@'));
-            tenantDomain = subject.substring(subject.lastIndexOf('@') + 1);
-        }
-
-        boolean accountLock = false;
-        if (userName != null) {
-            try {
-                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(userName
-                        , tenantDomain);
-            } catch (AccountLockServiceException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Error while calling the account lock service for user " + userName, e);
-                }
-                throw e;
-            }
-        }
-        return accountLock;
-    }
-
-    /**
      * Check whether user account is disabled or not.
      *
      * @param user Authenticated user.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -382,26 +382,27 @@ public class X509CertificateUtil {
     /**
      * Check whether user account is locked or not.
      *
-     * @param userName  user that passed from the cert CN value.
-     *  @param tenantDomain  from "authenticationcontext".
+     * @param subject userName that passed from the cert CN value.
      * @return boolean account locked or not.
      * @throws AccountLockServiceException
      */
-    public static boolean isAccountLock(String userName, String tenantDomain) throws AccountLockServiceException {
-        //Get the tenantaware username
-        String user = null;
-        if (userName.contains("@")) {
-            tenantDomain = userName.substring(userName.lastIndexOf('@') );
-            user = userName.replace(tenantDomain, "");
+    public static boolean isAccountLock(String subject) throws AccountLockServiceException {
+        //Get the tenantaware username & particular tenant domain
+        String userName = null;
+        String tenantDomain = null;
+        if (subject.contains("@")) {
+            userName = subject.substring(0, subject.lastIndexOf('@'));
+            tenantDomain = subject.substring(subject.lastIndexOf('@') + 1);
         }
+
         boolean accountLock = false;
         if (userName != null) {
             try {
-                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(user
+                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(userName
                         , tenantDomain);
             } catch (AccountLockServiceException e) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Error while calling the account lock service for user " + user, e);
+                    log.debug("Error while calling the account lock service for user " + userName, e);
                 }
                 throw e;
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -380,6 +380,30 @@ public class X509CertificateUtil {
     }
 
     /**
+     * Check whether user account is locked or not.
+     *
+     * @param user Authenticated user.
+     * @return boolean account locked or not.
+     * @throws AccountLockServiceException
+     */
+    public static boolean isAccountLock(AuthenticatedUser user) throws AccountLockServiceException {
+
+        boolean accountLock = false;
+        if (user != null) {
+            try {
+                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(user
+                        .getUserName(), user.getTenantDomain());
+            } catch (AccountLockServiceException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error while calling the account lock service for user " + user.getUserName(), e);
+                }
+                throw e;
+            }
+        }
+        return accountLock;
+    }
+
+    /**
      * Get the user account state by checking  whether the user account is locked or not.
      *
      * @param subject userName that passed from the cert CN value.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -382,21 +382,21 @@ public class X509CertificateUtil {
     /**
      * Check whether user account is locked or not.
      *
-     * @param user  user that passed from the cert CN value.
+     * @param userName  user that passed from the cert CN value.
      *  @param tenantDomain  from "authenticationcontex".
      * @return boolean account locked or not.
      * @throws AccountLockServiceException
      */
-    public static boolean isAccountLock(String user, String tenantDomain) throws AccountLockServiceException {
+    public static boolean isAccountLock(String userName, String tenantDomain) throws AccountLockServiceException {
 
         boolean accountLock = false;
-        if (user != null) {
+        if (userName != null) {
             try {
-                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(user
+                accountLock = X509CertificateDataHolder.getInstance().getAccountLockService().isAccountLocked(userName
                         , tenantDomain);
             } catch (AccountLockServiceException e) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Error while calling the account lock service for user " + user, e);
+                    log.debug("Error while calling the account lock service for user " + userName, e);
                 }
                 throw e;
             }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
@@ -368,7 +368,7 @@ public class X509CertificateAuthenticatorTest {
                         Matchers.anyBoolean())).thenReturn(true);
         mockStatic(IdentityUtil.class);
         when(X509CertificateUtil
-                .getAccountState(Matchers.anyString())).thenReturn(false);
+                .isAccountLock(Matchers.anyString())).thenReturn(false);
         when(X509CertificateUtil
                 .isAccountDisabled(Matchers.any(AuthenticatedUser.class))).thenReturn(false);
         when(IdentityUtil.getPrimaryDomainName()).thenReturn("PRIMARY");

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
@@ -368,7 +368,7 @@ public class X509CertificateAuthenticatorTest {
                         Matchers.anyBoolean())).thenReturn(true);
         mockStatic(IdentityUtil.class);
         when(X509CertificateUtil
-                .isAccountLock(Matchers.anyString())).thenReturn(false);
+                .getAccountState(Matchers.anyString())).thenReturn(false);
         when(X509CertificateUtil
                 .isAccountDisabled(Matchers.any(AuthenticatedUser.class))).thenReturn(false);
         when(IdentityUtil.getPrimaryDomainName()).thenReturn("PRIMARY");

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
@@ -368,7 +368,7 @@ public class X509CertificateAuthenticatorTest {
                         Matchers.anyBoolean())).thenReturn(true);
         mockStatic(IdentityUtil.class);
         when(X509CertificateUtil
-                .isAccountLock(Matchers.anyString(),Matchers.anyString())).thenReturn(false);
+                .isAccountLock(Matchers.anyString())).thenReturn(false);
         when(X509CertificateUtil
                 .isAccountDisabled(Matchers.any(AuthenticatedUser.class))).thenReturn(false);
         when(IdentityUtil.getPrimaryDomainName()).thenReturn("PRIMARY");

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
@@ -368,7 +368,7 @@ public class X509CertificateAuthenticatorTest {
                         Matchers.anyBoolean())).thenReturn(true);
         mockStatic(IdentityUtil.class);
         when(X509CertificateUtil
-                .isAccountLock(Matchers.any(AuthenticatedUser.class))).thenReturn(false);
+                .isAccountLock(Matchers.anyString(),Matchers.anyString())).thenReturn(false);
         when(X509CertificateUtil
                 .isAccountDisabled(Matchers.any(AuthenticatedUser.class))).thenReturn(false);
         when(IdentityUtil.getPrimaryDomainName()).thenReturn("PRIMARY");


### PR DESCRIPTION
## Purpose
> This is regarding the fix which was given by https://github.com/wso2/product-is/issues/8330 for 5.8.0 version and extended to 5.10.0 version as well.

## Approach
> The previous fix had two main limitations
> The previous implementation (the fix) was passed the "Authenticated user" object to the "isAccountLocked" method when checking the user account lock status and the tenant and user names are retrieving through that object. But this is failing in the first step authentication (As in the second step authenticated user the object is not null.). 
To overcome this bottleneck, the certificate's CN value is passed as the subject value and the tenant and user names are retrieving through that.
 > The previous implementation (the fix) was used the "authenticatedUser.getAuthenticatedSubjectIdentifier()" String to compare the user name with cert's subject value. but this is also failing when the user is from a different tenant or different domain.
To overcome that the "getAuthenticatedUserName" method has been introduced to check the authenticated user's tenant domain and verify whether it from the super tenant or different tenant.



