### PR TITLE
Fix OSGi package name

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -89,11 +89,11 @@
                         <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${pom.artifactId}</Bundle-Name>
                         <Private-Package>
-                            org.wso2.carbon.identity.framework.authenticator.x509Certificate.internal
+                            org.wso2.carbon.identity.authenticator.x509Certificate.internal
                         </Private-Package>
                         <Export-Package>
-                            !org.wso2.carbon.identity.framework.authenticator.x509Certificate.internal,
-                            org.wso2.carbon.identity.framework.authenticator.x509Certificate.*,
+                            !org.wso2.carbon.identity.authenticator.x509Certificate.internal,
+                            org.wso2.carbon.identity.authenticator.x509Certificate.*,
                         </Export-Package>
                         <Import-Package>
                             javax.servlet; version=2.4.0,


### PR DESCRIPTION
## Purpose
> Fix package name changed by mistake in https://github.com/wso2-extensions/identity-outbound-auth-x509/pull/54/files#diff-588c885c2f8905fecafd52f125d28a6d79eb4f9312d72bf03b9a0e0fd3a6460dL77