### PR TITLE
Fix the username mismatch issue when using x509 as the second step

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -37,6 +37,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+            <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -51,7 +56,14 @@
             <artifactId>powermock-api-mockito</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
     <repositories>
         <repository>
             <id>wso2-nexus</id>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
@@ -56,6 +56,8 @@ public class X509CertificateConstants {
     public static final String USERNAME_NOT_FOUND_FOR_X509_CERTIFICATE_ATTRIBUTE = "18003";
     public static final String X509_CERTIFICATE_USERNAME = "X509CertificateUsername";
     public static final String USER_NOT_FOUND = "17001";
+    public static final String USER_ACCOUNT_LOCKED = "17002";
+    public static final String USER_ACCOUNT_DISABLED = "17010";
     public static final String X509_CERTIFICATE_NOT_VALID_ERROR_CODE = "18015";
     public static final String X509_CERTIFICATE_NOT_VALIDATED_ERROR_CODE = "17003";
     public static final String X509_CERTIFICATE_ALTERNATIVE_NAMES_REGEX_MULTIPLE_MATCHES_ERROR_CODE = "17004";
@@ -70,5 +72,6 @@ public class X509CertificateConstants {
     public static final int MAX_ITEM_LIMIT_UNLIMITED = -1;
     public static final String SEARCH_ALL_USERSTORES = "SearchAllUserStores";
     public static final String LOGIN_CLAIM_URIS = "LoginClaimURIs";
+    public static final String ACCOUNT_DISABLED_CLAIM = "http://wso2.org/claims/identity/accountDisabled";
 
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateDataHolder.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.authenticator.x509Certificate;
 
 import org.osgi.service.http.HttpService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.user.core.service.RealmService;
 
 /**
  * Singleton class to hold HTTP Service
@@ -27,6 +29,8 @@ public class X509CertificateDataHolder {
 
     private static volatile X509CertificateDataHolder dataHolder = null;
     private HttpService httpService;
+    private AccountLockService accountLockService;
+    private RealmService realmService;
 
     private X509CertificateDataHolder() {
     }
@@ -63,5 +67,51 @@ public class X509CertificateDataHolder {
      */
     public void setHttpService(HttpService httpService) {
         this.httpService = httpService;
+    }
+
+    /**
+     * Set account lock service.
+     *
+     * @return account lock service
+     */
+    public AccountLockService getAccountLockService() {
+
+        if (accountLockService == null) {
+            throw new RuntimeException("Account lock service has not been set.");
+        }
+        return accountLockService;
+    }
+
+    /**
+     * Get account lock service.
+     *
+     * @param accountLockService
+     */
+    public void setAccountLockService(AccountLockService accountLockService) {
+
+        this.accountLockService = accountLockService;
+    }
+
+    /***
+     * Get realm service.
+     *
+     * @return RealmService
+     */
+    public RealmService getRealmService() {
+
+        if (realmService == null) {
+            throw new RuntimeException("Realm service has not been set.");
+        }
+        return realmService;
+    }
+
+    /**
+     * Set realm service.
+     *
+     * @param realmService realm service to be set.
+     */
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/internal/X509CertificateServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/internal/X509CertificateServiceComponent.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.identity.authenticator.x509Certificate.X509CertificateAut
 import org.wso2.carbon.identity.authenticator.x509Certificate.X509CertificateConstants;
 import org.wso2.carbon.identity.authenticator.x509Certificate.X509CertificateDataHolder;
 import org.wso2.carbon.identity.authenticator.x509Certificate.X509CertificateServlet;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.user.core.service.RealmService;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
@@ -39,6 +41,13 @@ import java.util.Hashtable;
  * @scr.reference name="osgi.httpservice" interface="org.osgi.service.http.HttpService"
  * cardinality="1..1" policy="dynamic" bind="setHttpService"
  * unbind="unsetHttpService"
+ * @scr.reference name="accountLockService"
+ * interface="org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService"
+ * cardinality="1..1" policy="dynamic" bind="setAccountLockService"
+ * unbind="unsetAccountLockService"
+ * @scr.reference name="osgi.user.realm.service.default" interface="org.wso2.carbon.user.core.service.RealmService"
+ * cardinality="1..1" policy="dynamic" bind="setRealmService"
+ * unbind="unsetRealmService"
  */
 
 public class X509CertificateServiceComponent {
@@ -98,5 +107,31 @@ public class X509CertificateServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("HTTP Service is unset in the X509 Certificate Servlet");
         }
+    }
+
+    protected void setAccountLockService(AccountLockService accountLockService) {
+
+        X509CertificateDataHolder.getInstance().setAccountLockService(accountLockService);
+    }
+
+    protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+        X509CertificateDataHolder.getInstance().setAccountLockService(null);
+    }
+
+    protected void setRealmService(RealmService realmService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("RealmService is set in the X509 authenticator bundle.");
+        }
+        X509CertificateDataHolder.getInstance().setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("RealmService is unset in the X509 authenticator bundle.");
+        }
+        X509CertificateDataHolder.getInstance().setRealmService(null);
     }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
@@ -366,6 +367,10 @@ public class X509CertificateAuthenticatorTest {
                 .validateCertificate(Matchers.anyString(), Matchers.any(AuthenticationContext.class), any(byte[].class),
                         Matchers.anyBoolean())).thenReturn(true);
         mockStatic(IdentityUtil.class);
+        when(X509CertificateUtil
+                .isAccountLock(Matchers.anyString())).thenReturn(false);
+        when(X509CertificateUtil
+                .isAccountDisabled(Matchers.any(AuthenticatedUser.class))).thenReturn(false);
         when(IdentityUtil.getPrimaryDomainName()).thenReturn("PRIMARY");
         if (exceptionShouldThrown) {
             try {

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
                 <version>${identity.x509Certificate.validation.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+                <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+                <version>${carbon.identity.account.lock.handler.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
@@ -70,6 +75,13 @@
                 <artifactId>powermock-api-mockito</artifactId>
                 <version>${org.powermock.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.agent</artifactId>
+                <classifier>runtime</classifier>
+                <scope>test</scope>
+                <version>${jacoco.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -201,5 +213,11 @@
         <org.apache.oltu.oauth2.common>1.0.1</org.apache.oltu.oauth2.common>
         <testng.version>6.9.10</testng.version>
         <org.powermock.version>1.7.4</org.powermock.version>
+        <jacoco.version>0.7.9</jacoco.version>
+
+        <!--Carbon Identity Extension Versions-->
+        <carbon.identity.account.lock.handler.version>1.4.37</carbon.identity.account.lock.handler.version>
+        <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
+        </carbon.identity.account.lock.handler.imp.pkg.version.range>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
Resolves [product-is #13381](https://github.com/wso2/product-is/issues/13381) by front-porting the following PRs

- #48 
- #49 
- #50 
- #51

Webapp changes are done in [wso2/identity-apps #3014](https://github.com/wso2/identity-apps/pull/3014)
