### PR TITLE
Fix the X509 Authentication failure for secondary user store users - unit tests

### DIFF
--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
@@ -20,6 +20,7 @@
 package org.wso2.carbon.identity.authenticator.x509Certificate;
 
 import org.mockito.Matchers;
+import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -33,6 +34,8 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 
 import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateFactory;
@@ -43,6 +46,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.bind.DatatypeConverter;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -53,7 +58,7 @@ import static org.testng.Assert.fail;
  * Tests for X509CertificateAuthenticator.
  */
 @PrepareForTest({X509CertificateAuthenticator.class, X509CertificateUtil.class, FrameworkUtils.class, IdentityUtil
-        .class})
+        .class, AbstractUserStoreManager.class})
 @PowerMockIgnore({ "javax.xml.*"})
 public class X509CertificateAuthenticatorTest {
 
@@ -190,6 +195,32 @@ public class X509CertificateAuthenticatorTest {
                     + "MnL4jtEI7tHs89GB+tfurD2dsSLW5ghXaDwmZTNuaUOgD8SRYwh0AG+en1Xk2v3/\n"
                     + "73zDq+0+CCuZv87EyQbA5QobwBlYNe45ocyxSzocJLTapVkcXytDr/+ZhhdB7ybL\n" + "UZoGqB7ayed6KBFi";
 
+    private static final String CERT_WITH_CN_AS_DOMAIN_PREPENDED_USER_NAME =
+            "MIIDiDCCAnACCQDq89XWcAHDDTANBgkqhkiG9w0BAQsFADCBhDELMAkGA1UEBhMC\n" +
+                    "U0wxEDAOBgNVBAgMB1dlc3Rlcm4xEDAOBgNVBAcMB0NvbG9tYm8xDTALBgNVBAoM\n" +
+                    "BFdTTzIxDDAKBgNVBAsMA0RldjEVMBMGA1UEAwwMU1RPUkUxL3VzZXIxMR0wGwYJ\n" +
+                    "KoZIhvcNAQkBFg5hZG1pbkB3c28yLmNvbTAgFw0yMjA3MDgwMzA0MThaGA8zMDIx\n" +
+                    "MTEwODAzMDQxOFowgYQxCzAJBgNVBAYTAlNMMRAwDgYDVQQIDAdXZXN0ZXJuMRAw\n" +
+                    "DgYDVQQHDAdDb2xvbWJvMQ0wCwYDVQQKDARXU08yMQwwCgYDVQQLDANEZXYxFTAT\n" +
+                    "BgNVBAMMDFNUT1JFMS91c2VyMTEdMBsGCSqGSIb3DQEJARYOYWRtaW5Ad3NvMi5j\n" +
+                    "b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQD7rN9k6Ltx85vTATN+\n" +
+                    "5H5r+mBVUMV7OpATNzhz0mKLr8oTao9uO4srAYyGTLGcg0kTpzLcAPpcgnbc8dt2\n" +
+                    "dmVpZAlIx5OBn/7oF2jiFlPz2pN+KFE8O4IweuIDPjodA6SEPY7+2DvpH0Me7HTA\n" +
+                    "ZV0D/yc/LH4NjHe7usLoffCJ9W0m/N01NXm2ZeuVkuaRqAmEzGisN8lcRdSUHQgv\n" +
+                    "UquH5YhlkrWFzHn3x3WoREWNCYt1egRHuif8WP5QHS/414gYvey/woA59TlQZRSQ\n" +
+                    "B1Ea7b9jcuBYlR7R6kaoNv4UMPPI42Ketu7uFM6etCOXrzVqCU+XPzymUKQfdB3+\n" +
+                    "dsvTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHNUGqVVTUB+u2RXC/eg5qcvZEpR\n" +
+                    "aZFJdhUzMDfP15t1PdchEb4ewrxlUIwu77oI9xABgTn9gwVBiz7DfejaN5xveeRX\n" +
+                    "KBHir+Hp29JByp5I6d76vttTPRIwx5OFxP9hea+yadBswL8z8md5vLMjcF8XJVmY\n" +
+                    "OPTSboIfBZTQWUUFdqQL2gcmpGna+QLDtbNdCOGO+57mInjQJsYC4uNiB0AohKe3\n" +
+                    "t0+WO4CowrWdcZTJLAegnipZ6CtZ5myCtyuWe25Xf5xIWLF9g7N80628B14hdbFw\n" +
+                    "Um+QzdwPxv1XoBOeT/r41I5Q1RnrPqArbIuYtVBDEYYk7MohXInMOlSbezo=";
+    @Mock
+    private UserRealm userRealmMock;
+
+    @Mock
+    private AbstractUserStoreManager userStoreManagerMock;
+
     @DataProvider(name = "provideX509Certificates")
     public Object[][] provideTestData() throws Exception {
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
@@ -302,7 +333,45 @@ public class X509CertificateAuthenticatorTest {
         parameterMap7.put(X509CertificateConstants.USER_NAME_REGEX, "^[a-zA-Z]{3}.[a-zA-Z]{2}$");
         parameterMap7.put(X509CertificateConstants.USERNAME, "CN");
         authenticatorConfig7.setParameterMap(parameterMap7);
-        
+
+        // Authenticating user when SEARCH_ALL_USERSTORES false and CN is domain prepended username.
+        X509Certificate cert8 = (X509Certificate) factory
+                .generateCertificate(new ByteArrayInputStream(DatatypeConverter.parseBase64Binary(
+                        CERT_WITH_CN_AS_DOMAIN_PREPENDED_USER_NAME)));
+        X509Certificate certificateArrayObject8[] = {cert8, null};
+
+        SequenceConfig sequenceConfig8 = new SequenceConfig();
+        Map<Integer, StepConfig> stepMap8 = new HashMap<>();
+        StepConfig stepConfig8 = new StepConfig();
+        stepConfig8.setAuthenticatedUser(null);
+        stepMap8.put(1, stepConfig8);
+        sequenceConfig8.setStepMap(stepMap8);
+
+        AuthenticatorConfig authenticatorConfig8 = new AuthenticatorConfig();
+        Map<String, String> parameterMap8 = new HashMap<>();
+        parameterMap8.put(X509CertificateConstants.SEARCH_ALL_USERSTORES, "false");
+        parameterMap8.put(X509CertificateConstants.USERNAME, "CN");
+        authenticatorConfig8.setParameterMap(parameterMap8);
+
+        // Authenticating user when SEARCH_ALL_USERSTORES true and CN is domain prepended username.
+        X509Certificate cert9 = (X509Certificate) factory
+                .generateCertificate(new ByteArrayInputStream(DatatypeConverter.parseBase64Binary(
+                        CERT_WITH_CN_AS_DOMAIN_PREPENDED_USER_NAME)));
+        X509Certificate certificateArrayObject9[] = {cert9, null};
+
+        SequenceConfig sequenceConfig9 = new SequenceConfig();
+        Map<Integer, StepConfig> stepMap9 = new HashMap<>();
+        StepConfig stepConfig9 = new StepConfig();
+        stepConfig9.setAuthenticatedUser(null);
+        stepMap9.put(1, stepConfig9);
+        sequenceConfig9.setStepMap(stepMap9);
+
+        AuthenticatorConfig authenticatorConfig9 = new AuthenticatorConfig();
+        Map<String, String> parameterMap9 = new HashMap<>();
+        parameterMap9.put(X509CertificateConstants.SEARCH_ALL_USERSTORES, "true");
+        parameterMap9.put(X509CertificateConstants.USERNAME, "CN");
+        authenticatorConfig9.setParameterMap(parameterMap9);
+
         return new Object[][] {
                 {
                         certificateArrayObject1, authenticatorConfig1, sequenceConfig1, true,
@@ -325,6 +394,12 @@ public class X509CertificateAuthenticatorTest {
                 },
                 {
                         certificateArrayObject7, authenticatorConfig7, sequenceConfig2, false, ""
+                },
+                {
+                        certificateArrayObject8, authenticatorConfig8, sequenceConfig8, false, ""
+                },
+                {
+                        certificateArrayObject9, authenticatorConfig9, sequenceConfig9, false, ""
                 },
                 };
     }
@@ -371,6 +446,16 @@ public class X509CertificateAuthenticatorTest {
                 .isAccountLock(Matchers.anyString())).thenReturn(false);
         when(X509CertificateUtil
                 .isAccountDisabled(Matchers.any(AuthenticatedUser.class))).thenReturn(false);
+
+        when(X509CertificateUtil.getUserRealm(anyString())).thenReturn(userRealmMock);
+
+        userStoreManagerMock = PowerMockito.mock(AbstractUserStoreManager.class);
+        when(userRealmMock.getUserStoreManager()).thenReturn(userStoreManagerMock);
+
+        String[] userList = new String[1];
+        userList[0] = "STORE1/user1";
+        when(userStoreManagerMock.listUsers(anyString(), anyInt())).thenReturn(userList);
+
         when(IdentityUtil.getPrimaryDomainName()).thenReturn("PRIMARY");
         if (exceptionShouldThrown) {
             try {

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtilTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtilTest.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.authenticator.x509Certificate;
+
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManagerImpl;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.fail;
+
+@PrepareForTest({X509CertificateUtil.class, FileBasedConfigurationBuilder.class, IdentityTenantUtil.class,
+        X509CertificateRealmServiceComponent.class, AbstractUserStoreManager.class})
+@PowerMockIgnore({"javax.xml.*"})
+public class X509CertificateUtilTest extends PowerMockTestCase {
+
+    private static final String CERT_WITH_ONE_CN_NO_AlTERNATIVE_NAMES =
+            "MIIDhDCCAmwCCQCbjLuYujEEOjANBgkqhkiG9w0BAQsFADCBgjELMAkGA1UEBhMC\n"
+                    + "U0wxEDAOBgNVBAgMB1dlc3Rlcm4xETAPBgNVBAcMCFRhbmdhbGxlMQ0wCwYDVQQK\n"
+                    + "DARXU28yMQswCQYDVQQLDAJRQTEPMA0GA1UEAwwGd3NvMmlzMSEwHwYJKoZIhvcN\n"
+                    + "AQkBFhJidWRkaGltYXVAd3NvMi5jb20wIBcNMTkwNTE1MTMzOTMwWhgPMjExOTA0\n"
+                    + "MjExMzM5MzBaMIGCMQswCQYDVQQGEwJTTDEQMA4GA1UECAwHV2VzdGVybjERMA8G\n"
+                    + "A1UEBwwIVGFuZ2FsbGUxDTALBgNVBAoMBFdTbzIxCzAJBgNVBAsMAlFBMQ8wDQYD\n"
+                    + "VQQDDAZ3c28yaXMxITAfBgkqhkiG9w0BCQEWEmJ1ZGRoaW1hdUB3c28yLmNvbTCC\n"
+                    + "ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL/qkwNCSehYeaUQSg+1Jr7J\n"
+                    + "U+r60DZnhak0hSUCvMesY1l8JfXjp/Ml9pjndD8XU1QOqnSZXLKPIpC55vXTPAfi\n"
+                    + "TIOgbeDDw6X+mnkE1XSzuwuru/9vdoGMIx4uF0SJhy1Bt1ZwmnKarwlQY0BNeDOg\n"
+                    + "LEgAKofsZdWQ3XrSPCohXej193+t9VlX+/67oqpm/t9Q4F71wBSj02iqEw2Wsmze\n"
+                    + "VrbFhliBko+WA5hk6/l5rmtPyl62+fSwV/1Xt7bylqbHuYeXzVJPsgMQTgg6WOsi\n"
+                    + "P7/51DnbWN7LBbvqszCRl0zWNn6DrHVgxhNX09jZB14+PLe84uviy52rZb9M+SsC\n"
+                    + "AwEAATANBgkqhkiG9w0BAQsFAAOCAQEABasjO16I3cNrTmvd2TFzRdSXWg9G2kMa\n"
+                    + "8USm1U1BadnkaDTeKUK53yTndmAizlYUHqQHWJws+tZNWX2oyXP7caps64VL4Ojb\n"
+                    + "L3iOq3zZvAz7Fehdk84lhgZl+gX8BX+EnLDdv+/ImuHBwsYWN2ibKuzsKZP/fbDT\n"
+                    + "y0Q5NlOHiTTJ/njdDU7FIsz2m3Y3C/KFAoQvCmCjSJL1xRiaRgfNl6vlkr99eXqs\n"
+                    + "mv4JKSOXDgc9r0SbEsE1UBL/ShEaFZJPGv7afom+tGfyGoTUspWp5RkiCAi0z0Ie\n"
+                    + "+gBGPDN+2G5+JD9UgcyjscttPDVR6C/Bkf11RA2FCjO5VmRKGoFRRg==";
+    @Mock
+    private FileBasedConfigurationBuilder fileBasedConfigurationBuilder;
+    @Mock
+    private RealmService realmService;
+    @Mock
+    private UserRealm userRealm;
+    @Mock
+    private AbstractUserStoreManager userStoreManager;
+    @Mock
+    private RevocationValidationManagerImpl revocationValidationManagerImpl;
+
+    @Test(dataProvider = "x509CertificateUtilDataProvider")
+    public void testValidateCertificate(String searchAllUserStores, String[] userList, boolean isUserExistsInStore,
+                                        boolean expectedResult, boolean isExceptionExpected,
+                                        String expectedExceptionMessage) throws Exception {
+
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        X509Certificate cert = (X509Certificate) factory
+                .generateCertificate(new ByteArrayInputStream(DatatypeConverter.parseBase64Binary(
+                        CERT_WITH_ONE_CN_NO_AlTERNATIVE_NAMES)));
+        byte[] data;
+        data = cert.getEncoded();
+
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put(X509CertificateConstants.USERNAME, "CN");
+        parameterMap.put(X509CertificateConstants.SEARCH_ALL_USERSTORES, searchAllUserStores);
+        authenticatorConfig.setParameterMap(parameterMap);
+
+        mockStatic(FileBasedConfigurationBuilder.class);
+        when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
+        when(fileBasedConfigurationBuilder.getAuthenticatorBean(X509CertificateConstants.AUTHENTICATOR_NAME))
+                .thenReturn(authenticatorConfig);
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(1);
+
+        mockStatic(X509CertificateRealmServiceComponent.class);
+        when(X509CertificateRealmServiceComponent.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(1)).thenReturn(userRealm);
+
+        userStoreManager = PowerMockito.mock(AbstractUserStoreManager.class);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+
+        when(userStoreManager.listUsers(anyString(), anyInt())).thenReturn(userList);
+        when(userStoreManager.isExistingUser(anyString())).thenReturn(isUserExistsInStore);
+
+        PowerMockito.whenNew(RevocationValidationManagerImpl.class).withNoArguments()
+                .thenReturn(revocationValidationManagerImpl);
+
+        if (!isExceptionExpected) {
+            boolean result =
+                    X509CertificateUtil.validateCertificate("user1", new AuthenticationContext(), data,
+                            false);
+            Assert.assertEquals(result, expectedResult);
+        } else {
+            try {
+                boolean result =
+                        X509CertificateUtil.validateCertificate("user1", new AuthenticationContext(), data,
+                                false);
+                fail("expected exception to be thrown but nothing was thrown");
+            } catch (Exception e) {
+                Assert.assertEquals(e.getMessage(), expectedExceptionMessage);
+            }
+        }
+    }
+
+    @DataProvider(name = "x509CertificateUtilDataProvider")
+    public Object[][] provideTestData() {
+
+        String[] listUsers1 = new String[1];
+        listUsers1[0] = "user1";
+
+        return new Object[][]{
+                {
+                    "true", listUsers1, true, true, false, ""
+                },
+                {
+                    "false", listUsers1, true, true, false, ""
+                },
+                {
+                    "false", listUsers1, false, true, true, " Unable to find X509 Certificate's user in user store. "
+                },
+        };
+    }
+}

--- a/component/authenticator/src/test/resources/testng.xml
+++ b/component/authenticator/src/test/resources/testng.xml
@@ -21,6 +21,7 @@
         <!--<parameter name="log-level" value="debug"/>-->
         <classes>
             <class name="org.wso2.carbon.identity.authenticator.x509Certificate.X509CertificateAuthenticatorTest"/>
+            <class name="org.wso2.carbon.identity.authenticator.x509Certificate.X509CertificateUtilTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
**Purpose**

Unit tests for the fix done in https://github.com/wso2-extensions/identity-outbound-auth-x509/pull/62 to resolve the issue  https://github.com/wso2/product-is/issues/14028