### PR TITLE
Fix username and tenatdomain resolve issue

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -68,7 +68,7 @@
         <repository>
             <id>wso2-nexus</id>
             <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -413,12 +413,8 @@ public class X509CertificateUtil {
     public static boolean isAccountLock(String subject) throws AccountLockServiceException {
 
         // Get the tenant aware username & particular tenant domain
-        String userName = subject;
-        String tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-        if (subject.contains("@")) {
-            userName = subject.substring(0, subject.lastIndexOf('@'));
-            tenantDomain = subject.substring(subject.lastIndexOf('@') + 1);
-        }
+        String userName = MultitenantUtils.getTenantAwareUsername(subject);
+        String tenantDomain = MultitenantUtils.getTenantDomain(subject);
 
         boolean accountLock = false;
         if (userName != null) {


### PR DESCRIPTION
## Purpose
> When Email as username is enabled, X509 certificate authenticator fails to resolve tenant domain. This fix is to correctly resolve username and tenant domain of the user in both email as username enable and disabled scenarios.

Related Issues:
- Fixes https://github.com/wso2/product-is/issues/14307 