### PR TITLE
fix: rename x509 authn displayName

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
@@ -30,7 +30,7 @@ public class X509CertificateConstants {
     }
 
     public static final String AUTHENTICATOR_NAME = "x509CertificateAuthenticator";
-    public static final String AUTHENTICATOR_FRIENDLY_NAME = "X509Certificate";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "X509 Certificate";
     public static final String CLAIM_DIALECT_URI = "http://wso2.org/claims/userCertificate";
     public static final String DEFAULT = "default";
     public static final String X_509_CERTIFICATE = "javax.servlet.request.X509Certificate";


### PR DESCRIPTION
## Purpose
> Renames `x509Certificate` to `x509 Certificate`