### PR TITLE
[2.0.x] Multi login claim URI for SearchAllUserStores case

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -218,7 +218,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
     /**
      * Resolves username of the subject attribute.
      *
-     * @param identifier            username
+     * @param identifier            identifier specified in the certificate
      * @param authenticationContext authentication context
      *
      * @return resolved username

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -187,7 +187,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                 } else {
                     String userName = null;
                     try {
-                        userName = resolveIdentifier((String) authenticationContext.getProperty(
+                        userName = resolveUsernameFromIdentifier((String) authenticationContext.getProperty(
                                 X509CertificateConstants.X509_CERTIFICATE_USERNAME), authenticationContext);
                     } catch (UserStoreException | AuthenticationFailedException e) {
                         throw new AuthenticationFailedException("Error occurred while resolving the username", e);
@@ -223,7 +223,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
      *
      * @return resolved username
      */
-    private String resolveIdentifier(String identifier, AuthenticationContext authenticationContext)
+    private String resolveUsernameFromIdentifier(String identifier, AuthenticationContext authenticationContext)
             throws AuthenticationFailedException, UserStoreException {
 
         if (getAuthenticatorConfig().getParameterMap().containsKey(X509CertificateConstants.LOGIN_CLAIM_URIS)) {
@@ -231,7 +231,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                     .get(X509CertificateConstants.LOGIN_CLAIM_URIS).split(",");
 
             String tenantDomain = authenticationContext.getTenantDomain();
-            if (tenantDomain == null || tenantDomain.isEmpty()) {
+            if (StringUtils.isEmpty(tenantDomain)) {
                 tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
             }
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -248,7 +248,6 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                     throw new AuthenticationFailedException("Conflicting users with claim value: " + identifier);
                 }
             }
-            throw new AuthenticationFailedException("No user found with claim value: " + identifier);
         }
         return identifier;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -185,8 +185,14 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                     }
                     authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_USERNAME, subjectAttribute);
                 } else {
-                    String userName = (String) authenticationContext
-                            .getProperty(X509CertificateConstants.X509_CERTIFICATE_USERNAME);
+                    String userName = null;
+                    try {
+                        userName = resolveIdentifier((String) authenticationContext.getProperty(
+                                X509CertificateConstants.X509_CERTIFICATE_USERNAME), authenticationContext);
+                    } catch (UserStoreException | AuthenticationFailedException e) {
+                        throw new AuthenticationFailedException("Error occurred while resolving the username", e);
+                    }
+
                     if (StringUtils.isEmpty(userName)) {
                         authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,
                                 X509CertificateConstants.USERNAME_NOT_FOUND_FOR_X509_CERTIFICATE_ATTRIBUTE);
@@ -207,6 +213,44 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                     X509CertificateConstants.X509_CERTIFICATE_NOT_FOUND_ERROR_CODE);
             throw new AuthenticationFailedException("Unable to find X509 Certificate in browser");
         }
+    }
+
+    /**
+     * Resolves username of the subject attribute.
+     *
+     * @param identifier            username
+     * @param authenticationContext authentication context
+     *
+     * @return resolved username
+     */
+    private String resolveIdentifier(String identifier, AuthenticationContext authenticationContext)
+            throws AuthenticationFailedException, UserStoreException {
+
+        if (getAuthenticatorConfig().getParameterMap().containsKey(X509CertificateConstants.LOGIN_CLAIM_URIS)) {
+            String[] attributeClaimUris = getAuthenticatorConfig().getParameterMap()
+                    .get(X509CertificateConstants.LOGIN_CLAIM_URIS).split(",");
+
+            String tenantDomain = authenticationContext.getTenantDomain();
+            if (tenantDomain == null || tenantDomain.isEmpty()) {
+                tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+            }
+
+            AbstractUserStoreManager aum = (AbstractUserStoreManager) X509CertificateUtil
+                    .getUserRealmByTenantDomain(tenantDomain).getUserStoreManager();
+
+            for (String attributeClaimUri : attributeClaimUris) {
+                String[] usersWithClaim = aum.getUserList(attributeClaimUri, identifier, null);
+                if (usersWithClaim.length == 1) {
+                    return usersWithClaim[0];
+                } else if (usersWithClaim.length > 1) {
+                    authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,
+                            X509CertificateConstants.USERNAME_CONFLICT);
+                    throw new AuthenticationFailedException("Conflicting users with claim value: " + identifier);
+                }
+            }
+            throw new AuthenticationFailedException("No user found with claim value: " + identifier);
+        }
+        return identifier;
     }
 
     /**

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -261,7 +261,7 @@ public class X509CertificateUtil {
     public static UserRealm getUserRealmByTenantDomain(String tenantDomain) throws AuthenticationFailedException {
 
         UserRealm userRealm = null;
-        log.debug(String.format("Getting userRealm for tenantDomain: " + tenantDomain));
+        log.debug("Getting userRealm for tenantDomain: " + tenantDomain);
 
         try {
             if (StringUtils.isNotEmpty(tenantDomain)) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -261,7 +261,7 @@ public class X509CertificateUtil {
     public static UserRealm getUserRealmByTenantDomain(String tenantDomain) throws AuthenticationFailedException {
 
         UserRealm userRealm = null;
-        log.debug(String.format("Getting userRealm for tenantDomain: %s", tenantDomain));
+        log.debug(String.format("Getting userRealm for tenantDomain: " + tenantDomain));
 
         try {
             if (StringUtils.isNotEmpty(tenantDomain)) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -259,8 +259,8 @@ public class X509CertificateUtil {
      * @throws AuthenticationFailedException if error occurred while getting user realm.
      */
     public static UserRealm getUserRealmByTenantDomain(String tenantDomain) throws AuthenticationFailedException {
-        UserRealm userRealm = null;
 
+        UserRealm userRealm = null;
         log.debug(String.format("Getting userRealm for tenantDomain: %s", tenantDomain));
 
         try {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -261,7 +261,9 @@ public class X509CertificateUtil {
     public static UserRealm getUserRealmByTenantDomain(String tenantDomain) throws AuthenticationFailedException {
 
         UserRealm userRealm = null;
-        log.debug("Getting userRealm for tenantDomain: " + tenantDomain);
+        if (log.isDebugEnabled()) {
+            log.debug("Getting userRealm for tenantDomain: " + tenantDomain);
+        }
 
         try {
             if (StringUtils.isNotEmpty(tenantDomain)) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateUtil.java
@@ -252,6 +252,31 @@ public class X509CertificateUtil {
     }
 
     /**
+     * Get user realm by tenant domain.
+     *
+     * @param tenantDomain tenant domain
+     * @return user realm
+     * @throws AuthenticationFailedException if error occurred while getting user realm.
+     */
+    public static UserRealm getUserRealmByTenantDomain(String tenantDomain) throws AuthenticationFailedException {
+        UserRealm userRealm = null;
+
+        log.debug(String.format("Getting userRealm for tenantDomain: %s", tenantDomain));
+
+        try {
+            if (StringUtils.isNotEmpty(tenantDomain)) {
+                int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+                RealmService realmService = X509CertificateRealmServiceComponent.getRealmService();
+                userRealm = realmService.getTenantUserRealm(tenantId);
+            }
+        } catch (UserStoreException e) {
+            throw new AuthenticationFailedException(String.format("Cannot find the user realm for the tenantDomain: %s",
+                    tenantDomain), e);
+        }
+        return userRealm;
+    }
+
+    /**
      * Check the revocation status of the certificate
      *
      * @param x509Certificate x509 certificate


### PR DESCRIPTION
## Purpose
The current version of  x509 certification based authenticator does not support multi attribute login. This effort will handle the case where username get resolved when multi attribute login is used.

Resolves https://github.com/wso2/product-is/issues/15903
Related PRs https://github.com/wso2-extensions/identity-outbound-auth-x509/pull/35