### PR TITLE
Tenant qualify commonauth and error page URLs

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -36,6 +36,8 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -110,7 +112,13 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
             throws AuthenticationFailedException {
         try {
             if (authenticationContext.isRetrying()) {
-                String errorPageUrl = IdentityUtil.getServerURL(X509CertificateConstants.ERROR_PAGE, false, false);
+                String errorPageUrl;
+                try {
+                    errorPageUrl = ServiceURLBuilder.create().addPath(X509CertificateConstants.ERROR_PAGE).build()
+                            .getAbsoluteInternalURL();
+                } catch (URLBuilderException e) {
+                    throw new RuntimeException("Error occurred while building URL.", e);
+                }
                 String redirectUrl = errorPageUrl + ("?" + FrameworkConstants.SESSION_DATA_KEY + "="
                         + authenticationContext.getContextIdentifier()) + "&" + X509CertificateConstants.AUTHENTICATORS
                         + "=" + getName() + X509CertificateConstants.RETRY_PARAM_FOR_CHECKING_CERTIFICATE

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
@@ -18,7 +18,8 @@
  */
 package org.wso2.carbon.identity.authenticator.x509Certificate;
 
-import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -59,8 +60,15 @@ public class X509CertificateServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
             throws ServletException, IOException {
-        String commonAuthURL = IdentityUtil
-                .getServerURL(X509CertificateConstants.COMMON_AUTH, false, true);
+
+        String commonAuthURL;
+        try {
+            commonAuthURL = ServiceURLBuilder.create().addPath(X509CertificateConstants.COMMON_AUTH).build()
+                    .getAbsoluteInternalURL();
+        } catch (URLBuilderException e) {
+            throw new RuntimeException("Error occurred while building URL.", e);
+        }
+
         String param = servletRequest.getParameter(X509CertificateConstants.SESSION_DATA_KEY);
         if (param == null) {
             throw new IllegalArgumentException(X509CertificateConstants.SESSION_DATA_KEY

--- a/component/setup.txt
+++ b/component/setup.txt
@@ -8,7 +8,7 @@ Tested Platform:
 
 - UBUNTU 14.04
 - WSO2 IS 5.1.0
-- Java 1.7
+- Java 1.8
 
 Do the following:
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR uses the ServerURLBuilder to build the commonauth and error page URLs with the tenant domain to support tenant qualified URLs.

Related issue: https://github.com/wso2/product-is/issues/9006