### PR TITLE
Implement Certificate Extraction at X509 Servlet

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -160,7 +160,11 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                                                  HttpServletResponse httpServletResponse,
                                                  AuthenticationContext authenticationContext)
             throws AuthenticationFailedException {
-        Object object = httpServletRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE);
+
+        Object object = authenticationContext.getProperty(X509CertificateConstants.X_509_CERTIFICATE);
+        if (object == null) {
+            object = httpServletRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE);
+        }
         if (object != null) {
             X509Certificate[] certificates;
             if (object instanceof X509Certificate[]) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -1,20 +1,19 @@
 /*
- *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.authenticator.x509Certificate;
@@ -38,15 +37,14 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
 import java.security.cert.CertificateEncodingException;
@@ -83,7 +81,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
 
     private static final Log log = LogFactory.getLog(X509CertificateAuthenticator.class);
 
-    public X509CertificateAuthenticator(){
+    public X509CertificateAuthenticator() {
 
         subjectAttributePattern = getAuthenticatorConfig().getParameterMap()
                 .get(X509CertificateConstants.USER_NAME_REGEX);
@@ -110,6 +108,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                                                  HttpServletResponse httpServletResponse,
                                                  AuthenticationContext authenticationContext)
             throws AuthenticationFailedException {
+
         try {
             if (authenticationContext.isRetrying()) {
                 String errorPageUrl;
@@ -185,17 +184,19 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                 if (alternativeNamePattern != null) {
                      alternativeName = getMatchedAlternativeName(cert, authenticationContext);
                      validateUsingSubject(alternativeName, authenticationContext, cert, claims);
-                     if(log.isDebugEnabled()){
+                     if (log.isDebugEnabled()) {
                          log.debug("Certificate validated using the alternative name: " + alternativeName);
                      }
-                    authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_USERNAME, alternativeName);
-                } else if (subjectAttributePattern != null){
+                    authenticationContext
+                            .setProperty(X509CertificateConstants.X509_CERTIFICATE_USERNAME, alternativeName);
+                } else if (subjectAttributePattern != null) {
                     subjectAttribute = getMatchedSubjectAttribute(certAttributes, authenticationContext);
                     validateUsingSubject(subjectAttribute, authenticationContext, cert, claims);
-                    if(log.isDebugEnabled()){
+                    if (log.isDebugEnabled()) {
                         log.debug("Certificate validated using the certificate subject attribute: " + subjectAttribute);
                     }
-                    authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_USERNAME, subjectAttribute);
+                    authenticationContext
+                            .setProperty(X509CertificateConstants.X509_CERTIFICATE_USERNAME, subjectAttribute);
                 } else {
                     String userName = null;
                     try {
@@ -212,7 +213,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                                 "Couldn't find the username for X509Certificate's attribute");
                     } else {
                         validateUsingSubject(userName, authenticationContext, cert, claims);
-                        if(log.isDebugEnabled()){
+                        if (log.isDebugEnabled()) {
                             log.debug("Certificate validated using the certificate username attribute: " + userName);
                         }
                     }
@@ -294,7 +295,8 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
             if (log.isDebugEnabled()) {
                 log.debug(X509CertificateConstants.X509_CERTIFICATE_SUBJECTDN_REGEX_NO_MATCHES_ERROR);
             }
-            throw new AuthenticationFailedException(X509CertificateConstants.X509_CERTIFICATE_SUBJECTDN_REGEX_NO_MATCHES_ERROR);
+            throw new AuthenticationFailedException(
+                    X509CertificateConstants.X509_CERTIFICATE_SUBJECTDN_REGEX_NO_MATCHES_ERROR);
         } else if (matchedStringList.size() > 1) {
             authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,
                     X509CertificateConstants.X509_CERTIFICATE_SUBJECTDN_REGEX_MULTIPLE_MATCHES_ERROR_CODE);
@@ -450,7 +452,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
         }
         String userNameAttribute = getAuthenticatorConfig().getParameterMap().get(X509CertificateConstants.USERNAME);
         if (log.isDebugEnabled()) {
-            log.debug("Getting username attribute: "+ userNameAttribute);
+            log.debug("Getting username attribute: " + userNameAttribute);
         }
         for (Rdn distinguishNames : ldapDN.getRdns()) {
             claims.put(ClaimMapping.build(distinguishNames.getType(), distinguishNames.getType(),
@@ -502,7 +504,8 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
      * @param cert                  x509 certificate.
      * @param authenticationContext authenticationContext
      */
-    private String getMatchedAlternativeName(X509Certificate cert, AuthenticationContext authenticationContext) throws AuthenticationFailedException {
+    private String getMatchedAlternativeName(X509Certificate cert, AuthenticationContext authenticationContext)
+            throws AuthenticationFailedException {
 
         Set<String> matchedAlternativeNamesList = new HashSet<>();
         try {
@@ -510,14 +513,15 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
             if (altNames != null) {
                 for (List item : altNames) {
                     ASN1InputStream decoder = null;
-                    if (item.toArray()[1] instanceof byte[])
+                    if (item.toArray()[1] instanceof byte[]) {
                         decoder = new ASN1InputStream((byte[]) item.toArray()[1]);
-                    else if (item.toArray()[1] instanceof String) {
+                    } else if (item.toArray()[1] instanceof String) {
                         Matcher m = alternativeNamesPatternCompiled.matcher((String) item.toArray()[1]);
                         addMatchStringsToList(m, matchedAlternativeNamesList);
                     }
-                    if (decoder == null)
+                    if (decoder == null) {
                         continue;
+                    }
                     String identity = decodeAlternativeName(decoder);
                     Matcher m = alternativeNamesPatternCompiled.matcher(identity);
                     addMatchStringsToList(m, matchedAlternativeNamesList);
@@ -545,7 +549,7 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
     }
 
     /**
-     * Get decoded alternative name
+     * Get decoded alternative name.
      *
      * @param decoder ASN1 Decoder
      */
@@ -624,7 +628,8 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
 
     private String getUserStoreDomainName(String userIdentifier, AuthenticationContext authenticationContext)
             throws UserStoreException, AuthenticationFailedException {
-        if (Boolean.valueOf(getAuthenticatorConfig().getParameterMap().get(X509CertificateConstants.SEARCH_ALL_USERSTORES))) {
+        if (Boolean.valueOf(getAuthenticatorConfig().getParameterMap()
+                .get(X509CertificateConstants.SEARCH_ALL_USERSTORES))) {
             UserStoreManager um = X509CertificateUtil.getUserRealm(userIdentifier).getUserStoreManager();
             String[] filteredUsers = um.listUsers(MultitenantUtils.getTenantAwareUsername(userIdentifier),
                     X509CertificateConstants.MAX_ITEM_LIMIT_UNLIMITED);
@@ -637,11 +642,12 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                 authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,
                         X509CertificateConstants.USERNAME_CONFLICT);
                 throw new AuthenticationFailedException("Conflicting users with user name: " + userIdentifier);
-            } else if (getAuthenticatorConfig().getParameterMap().containsKey(X509CertificateConstants.LOGIN_CLAIM_URIS)) {
+            } else if (getAuthenticatorConfig().getParameterMap()
+                    .containsKey(X509CertificateConstants.LOGIN_CLAIM_URIS)) {
                 String[] multiAttributeClaimUris = getAuthenticatorConfig().getParameterMap()
                         .get(X509CertificateConstants.LOGIN_CLAIM_URIS).split(",");
-                AbstractUserStoreManager aum = (AbstractUserStoreManager) X509CertificateUtil.getUserRealm(userIdentifier)
-                        .getUserStoreManager();
+                AbstractUserStoreManager aum = (AbstractUserStoreManager) X509CertificateUtil
+                        .getUserRealm(userIdentifier).getUserStoreManager();
                 for (String multiAttributeClaimUri : multiAttributeClaimUris) {
                     String[] usersWithClaim = aum.getUserList(multiAttributeClaimUri, userIdentifier, null);
                     if (usersWithClaim.length == 1) {
@@ -649,7 +655,8 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                     } else if (usersWithClaim.length > 1) {
                         authenticationContext.setProperty(X509CertificateConstants.X509_CERTIFICATE_ERROR_CODE,
                                 X509CertificateConstants.USERNAME_CONFLICT);
-                        throw new AuthenticationFailedException("Conflicting users with claim value: " + userIdentifier);
+                        throw new AuthenticationFailedException("Conflicting users with claim value: "
+                                + userIdentifier);
                     }
                 }
                 throw new AuthenticationFailedException("Unable to find X509 Certificate's user in user store. ");

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
@@ -18,6 +18,8 @@
  */
 package org.wso2.carbon.identity.authenticator.x509Certificate;
 
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 
@@ -60,6 +62,12 @@ public class X509CertificateServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
             throws ServletException, IOException {
+
+        AuthenticationContext authenticationContext = FrameworkUtils.getContextData(servletRequest);
+        if (authenticationContext != null) {
+            authenticationContext.setProperty(X509CertificateConstants.X_509_CERTIFICATE,
+                    servletRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE));
+        }
 
         String commonAuthURL;
         try {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
@@ -1,20 +1,19 @@
 /*
- *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.carbon.identity.authenticator.x509Certificate;
 
@@ -23,12 +22,12 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 
+import java.io.IOException;
+import java.net.URLEncoder;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.net.URLEncoder;
 
 /**
  * X509 Certificate Servlet.

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
@@ -432,6 +432,7 @@ public class X509CertificateAuthenticatorTest {
         AuthenticatorConfig authenticatorConfig = (AuthenticatorConfig) object1;
         authenticatorConfig1 = authenticatorConfig;
         when(mockRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE)).thenReturn(certificateArray);
+        authenticationContext.setProperty(X509CertificateConstants.X_509_CERTIFICATE, certificateArray);
         X509CertificateAuthenticator x509CertificateAuthenticator = new MockX509CertificateAuthenticator();
         X509CertificateAuthenticator spy = PowerMockito.spy(x509CertificateAuthenticator);
         SequenceConfig sequenceConfig = (SequenceConfig) object2;


### PR DESCRIPTION
### Purpose
- This PR implements certificate extraction at x509 servlet and pass it to the x509 authenticator through the authentication context.

### Related Issue
- https://github.com/wso2/product-is/issues/18437