### PR TITLE
Implement Certificate Extraction at X509 Servlet

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -160,7 +160,11 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
                                                  HttpServletResponse httpServletResponse,
                                                  AuthenticationContext authenticationContext)
             throws AuthenticationFailedException {
-        Object object = httpServletRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE);
+
+        Object object = authenticationContext.getProperty(X509CertificateConstants.X_509_CERTIFICATE);
+        if (object == null) {
+            object = httpServletRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE);
+        }
         if (object != null) {
             X509Certificate[] certificates;
             if (object instanceof X509Certificate[]) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
@@ -18,6 +18,8 @@
  */
 package org.wso2.carbon.identity.authenticator.x509Certificate;
 
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 
@@ -60,6 +62,12 @@ public class X509CertificateServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
             throws ServletException, IOException {
+
+        AuthenticationContext authenticationContext = FrameworkUtils.getContextData(servletRequest);
+        if (authenticationContext != null) {
+            authenticationContext.setProperty(X509CertificateConstants.X_509_CERTIFICATE,
+                    servletRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE));
+        }
 
         String commonAuthURL;
         try {

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticatorTest.java
@@ -432,6 +432,7 @@ public class X509CertificateAuthenticatorTest {
         AuthenticatorConfig authenticatorConfig = (AuthenticatorConfig) object1;
         authenticatorConfig1 = authenticatorConfig;
         when(mockRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE)).thenReturn(certificateArray);
+        authenticationContext.setProperty(X509CertificateConstants.X_509_CERTIFICATE, certificateArray);
         X509CertificateAuthenticator x509CertificateAuthenticator = new MockX509CertificateAuthenticator();
         X509CertificateAuthenticator spy = PowerMockito.spy(x509CertificateAuthenticator);
         SequenceConfig sequenceConfig = (SequenceConfig) object2;


### PR DESCRIPTION
### Purpose
- This PR implements certificate extraction at x509 servlet and pass it to the x509 authenticator through the authentication context.

### Related Issue
- https://github.com/wso2/product-is/issues/18437