### PR TITLE
Update Authentication Context Caches after Setting the Cert in the Servlet

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
@@ -1,20 +1,19 @@
 /*
- *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.carbon.identity.authenticator.x509Certificate;
 
@@ -23,12 +22,12 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 
+import java.io.IOException;
+import java.net.URLEncoder;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.net.URLEncoder;
 
 /**
  * X509 Certificate Servlet.
@@ -63,12 +62,6 @@ public class X509CertificateServlet extends HttpServlet {
     protected void doPost(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
             throws ServletException, IOException {
 
-        AuthenticationContext authenticationContext = FrameworkUtils.getContextData(servletRequest);
-        if (authenticationContext != null) {
-            authenticationContext.setProperty(X509CertificateConstants.X_509_CERTIFICATE,
-                    servletRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE));
-        }
-
         String commonAuthURL;
         try {
             commonAuthURL = ServiceURLBuilder.create().addPath(X509CertificateConstants.COMMON_AUTH).build()
@@ -82,10 +75,22 @@ public class X509CertificateServlet extends HttpServlet {
             throw new IllegalArgumentException(X509CertificateConstants.SESSION_DATA_KEY
                     + " parameter is null.");
         } else {
-            commonAuthURL += "?" + X509CertificateConstants.SESSION_DATA_KEY + "="
-                    + URLEncoder.encode(param, X509CertificateConstants.UTF_8) + "&"
-                    + X509CertificateConstants.SUCCESS + "=true";
-            servletResponse.sendRedirect(commonAuthURL);
+            AuthenticationContext authenticationContext = FrameworkUtils.getContextData(servletRequest);
+            try {
+                if (authenticationContext != null) {
+                    authenticationContext.setProperty(X509CertificateConstants.X_509_CERTIFICATE,
+                            servletRequest.getAttribute(X509CertificateConstants.X_509_CERTIFICATE));
+                }
+                commonAuthURL += "?" + X509CertificateConstants.SESSION_DATA_KEY + "="
+                        + URLEncoder.encode(param, X509CertificateConstants.UTF_8) + "&"
+                        + X509CertificateConstants.SUCCESS + "=true";
+                servletResponse.sendRedirect(commonAuthURL);
+            } finally {
+                if (authenticationContext != null) {
+                    FrameworkUtils.addAuthenticationContextToCache(
+                            authenticationContext.getContextIdentifier(), authenticationContext);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Purpose
- This PR fixes the issue [1] in a multi node setup with sticky sessions disabled by updating authentication context caches in all nodes after setting the certificate into it at the X509 certificate servlet.

### Related Issues
- https://github.com/wso2/product-is/issues/18437

[1] - https://github.com/wso2/product-is/issues/18437#issuecomment-1929320969