### PR TITLE
Use public hostname when redirecting from x509 authenticator

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateAuthenticator.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -113,8 +114,17 @@ public class X509CertificateAuthenticator extends AbstractApplicationAuthenticat
             if (authenticationContext.isRetrying()) {
                 String errorPageUrl;
                 try {
-                    errorPageUrl = ServiceURLBuilder.create().addPath(X509CertificateConstants.ERROR_PAGE).build()
-                            .getAbsoluteInternalURL();
+                    // Check if internal hostname should be used for redirect.
+                    boolean useInternalHostname = Boolean.parseBoolean(IdentityUtil.getProperty(
+                            X509CertificateConstants.USE_INTERNAL_HOSTNAME_FOR_REDIRECT));
+
+                    if (useInternalHostname) {
+                        errorPageUrl = ServiceURLBuilder.create().addPath(X509CertificateConstants.ERROR_PAGE).build()
+                                .getAbsoluteInternalURL();
+                    } else {
+                        errorPageUrl = ServiceURLBuilder.create().addPath(X509CertificateConstants.ERROR_PAGE).build()
+                                .getAbsolutePublicURL();
+                    }
                 } catch (URLBuilderException e) {
                     throw new RuntimeException("Error occurred while building URL.", e);
                 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateConstants.java
@@ -73,5 +73,6 @@ public class X509CertificateConstants {
     public static final String SEARCH_ALL_USERSTORES = "SearchAllUserStores";
     public static final String LOGIN_CLAIM_URIS = "LoginClaimURIs";
     public static final String ACCOUNT_DISABLED_CLAIM = "http://wso2.org/claims/identity/accountDisabled";
+    public static final String USE_INTERNAL_HOSTNAME_FOR_REDIRECT = "UseInternalHostnameForRedirect";
 
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/x509Certificate/X509CertificateServlet.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -64,8 +65,17 @@ public class X509CertificateServlet extends HttpServlet {
 
         String commonAuthURL;
         try {
-            commonAuthURL = ServiceURLBuilder.create().addPath(X509CertificateConstants.COMMON_AUTH).build()
-                    .getAbsoluteInternalURL();
+            // Check if internal hostname should be used for redirect.
+            boolean useInternalHostname = Boolean.parseBoolean(IdentityUtil.getProperty(
+                    X509CertificateConstants.USE_INTERNAL_HOSTNAME_FOR_REDIRECT));
+
+            if (useInternalHostname) {
+                commonAuthURL = ServiceURLBuilder.create().addPath(X509CertificateConstants.COMMON_AUTH).build()
+                        .getAbsoluteInternalURL();
+            } else {
+                commonAuthURL = ServiceURLBuilder.create().addPath(X509CertificateConstants.COMMON_AUTH).build()
+                        .getAbsolutePublicURL();
+            }
         } catch (URLBuilderException e) {
             throw new RuntimeException("Error occurred while building URL.", e);
         }


### PR DESCRIPTION
## Purpose
Issue: https://github.com/wso2/product-is/issues/26200

Fixed by changing the places that use **AbsoluteInternalURL** to use **AbsolutePublicURL** instead.

To use the internal hostname for X.509 authenticator redirections, add the following to the <PRODUCT_HOME>/repository/conf/deployment.toml file: 

```
[authentication.authenticator.x509_certificate.parameters]
UseInternalHostnameForRedirect = true
```

Since UseInternalHostnameForRedirect is a functional parameter that changes the behavior of the authenticator (similar to AuthenticationEndpoint and username), it is added under parameters.

Related:

- https://github.com/wso2/carbon-identity-framework/pull/7627
- https://github.com/wso2-extensions/identity-outbound-auth-x509/pull/110